### PR TITLE
移除上报消息为array时的文本转义

### DIFF
--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -34,7 +34,7 @@ func ToArrayMessage(e []message.IMessageElement, code int64, raw ...bool) (r []M
 		case *message.TextElement:
 			m = MSG{
 				"type": "text",
-				"data": map[string]string{"text": CQCodeEscapeText(o.Content)},
+				"data": map[string]string{"text": o.Content},
 			}
 		case *message.AtElement:
 			if o.Target == 0 {


### PR DESCRIPTION
参见 [消息格式](https://github.com/cqhttp/cqhttp-protocol/blob/master/legacy/Message.md#%E6%A0%BC%E5%BC%8F)

> 由于消息段不再将纯文本和多媒体内容放在一起，也就意味着任意一个字段的值都是真实值，而不再需要转义。