### PR TITLE
remove os.ModePerm

### DIFF
--- a/coolq/bot.go
+++ b/coolq/bot.go
@@ -191,7 +191,7 @@ func (bot *CQBot) dispatchEventMessage(m MSG) {
 			fn(m)
 			end := time.Now()
 			if end.Sub(start) > time.Second*5 {
-				log.Debugf("警告: 事件处理耗时超过 5 秒 (%v秒), 请检查应用是否有堵塞.", end.Sub(start)/time.Second)
+				log.Debugf("警告: 事件处理耗时超过 5 秒 (%v), 请检查应用是否有堵塞.", end.Sub(start))
 			}
 		}()
 	}

--- a/coolq/event.go
+++ b/coolq/event.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Mrs4s/go-cqhttp/global"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -374,7 +373,7 @@ func (bot *CQBot) checkMedia(e []message.IMessageElement) {
 					w.WriteUInt32(uint32(i.Size))
 					w.WriteString(i.Filename)
 					w.WriteString(i.Url)
-				}), os.ModePerm)
+				}), 0644)
 			}
 			i.Filename = filename
 		case *message.VoiceElement:
@@ -386,7 +385,7 @@ func (bot *CQBot) checkMedia(e []message.IMessageElement) {
 					log.Warnf("语音文件 %v 下载失败: %v", i.Name, err)
 					continue
 				}
-				_ = ioutil.WriteFile(path.Join(global.VOICE_PATH, i.Name), b, os.ModePerm)
+				_ = ioutil.WriteFile(path.Join(global.VOICE_PATH, i.Name), b, 0644)
 			}
 		case *message.ShortVideoElement:
 			filename := hex.EncodeToString(i.Md5) + ".video"
@@ -396,7 +395,7 @@ func (bot *CQBot) checkMedia(e []message.IMessageElement) {
 					w.WriteUInt32(uint32(i.Size))
 					w.WriteString(i.Name)
 					w.Write(i.Uuid)
-				}), os.ModePerm)
+				}), 0644)
 			}
 			i.Name = filename
 			i.Url = bot.Client.GetShortVideoUrl(i.Uuid, i.Md5)

--- a/global/fs.go
+++ b/global/fs.go
@@ -27,7 +27,7 @@ func ReadAllText(path string) string {
 }
 
 func WriteAllText(path, text string) {
-	_ = ioutil.WriteFile(path, []byte(text), 0777)
+	_ = ioutil.WriteFile(path, []byte(text), 0644)
 }
 
 func Check(err error) {

--- a/main.go
+++ b/main.go
@@ -37,17 +37,17 @@ func init() {
 		log.SetOutput(io.MultiWriter(os.Stderr, w))
 	}
 	if !global.PathExists(global.IMAGE_PATH) {
-		if err := os.MkdirAll(global.IMAGE_PATH, os.ModePerm); err != nil {
+		if err := os.MkdirAll(global.IMAGE_PATH, 0755); err != nil {
 			log.Fatalf("创建图片缓存文件夹失败: %v", err)
 		}
 	}
 	if !global.PathExists(global.VOICE_PATH) {
-		if err := os.MkdirAll(global.VOICE_PATH, os.ModePerm); err != nil {
+		if err := os.MkdirAll(global.VOICE_PATH, 0755); err != nil {
 			log.Fatalf("创建语音缓存文件夹失败: %v", err)
 		}
 	}
 	if !global.PathExists(global.VIDEO_PATH) {
-		if err := os.MkdirAll(global.VIDEO_PATH, os.ModePerm); err != nil {
+		if err := os.MkdirAll(global.VIDEO_PATH, 0755); err != nil {
 			log.Fatalf("创建视频缓存文件夹失败: %v", err)
 		}
 	}
@@ -135,7 +135,7 @@ func main() {
 	if !global.PathExists("device.json") {
 		log.Warn("虚拟设备信息不存在, 将自动生成随机设备.")
 		client.GenRandomDevice()
-		_ = ioutil.WriteFile("device.json", client.SystemDeviceInfo.ToJson(), os.ModePerm)
+		_ = ioutil.WriteFile("device.json", client.SystemDeviceInfo.ToJson(), 0644)
 		log.Info("已生成设备信息并保存到 device.json 文件.")
 	} else {
 		log.Info("将使用 device.json 内的设备信息运行Bot.")
@@ -171,7 +171,7 @@ func main() {
 		if !rsp.Success {
 			switch rsp.Error {
 			case client.NeedCaptcha:
-				_ = ioutil.WriteFile("captcha.jpg", rsp.CaptchaImage, os.ModePerm)
+				_ = ioutil.WriteFile("captcha.jpg", rsp.CaptchaImage, 0644)
 				img, _, _ := image.Decode(bytes.NewReader(rsp.CaptchaImage))
 				fmt.Println(asciiart.New("image", img).Art)
 				log.Warn("请输入验证码 (captcha.jpg)： (Enter 提交)")


### PR DESCRIPTION
1967e687af14466d6654e61fa214acb96c95a83a 里改了一部分权限。
其实该 commit 改后，确实比改前的表现好多了（改前允许系统里所有其他用户和组进入 go-cqhttp 建立的文件夹随意读写其中文件，却唯独不允许 go-cqhttp 本身读写…… 为什么要这样设权限……）
但这次给了过多权限，存在安全隐患（给了系统中所有用户和组将 go-cqhttp 接收到的文件当作可执行程序执行的权限，存在构造恶意 shell code 的风险）。

`os.ModePerm` 是和 `os.ModeType` 对偶的、系统中所有权限的总和。这两个常数存在的目的是以 `FileMode & os.ModeType` 或 `FileMode & os.ModePerm` 的方式来将 FileMode 劈成两个部分分别处理，并不是让用户选为新建文件的默认值。正如不应该把文件的类型设为 `os.ModeType` 一样（一个既是文件夹，又是普通文件，又是块设备，又是文本设备，又是管道，又是软链接的奇怪东西……），通常也不应该把文件的权限设为 `os.ModePerm`。

----

另一处修改是关于 `time.Duration` 打印的。
`time.Duration` 虽然底层是 `type Duration int64` 的纳秒数，但是[该类型实现了 `Stringer` 接口](https://golang.org/pkg/time/#Duration.String)，`fmt.Printf()` 会优先用该接口格式化。由于 `time.Duration / time.Duration` 的类型是 `time.Duration`，如果消息处理的用时是 `12.34s`，当前实现打印的结果将是 `12ns秒`。故将其修正为打印`12.34s`。