### PR TITLE
support silk audio

### DIFF
--- a/global/fs.go
+++ b/global/fs.go
@@ -1,17 +1,22 @@
 package global
 
 import (
-	log "github.com/sirupsen/logrus"
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path"
+
+	log "github.com/sirupsen/logrus"
 )
 
-var IMAGE_PATH = path.Join("data", "images")
+var (
+	IMAGE_PATH = path.Join("data", "images")
+	VOICE_PATH = path.Join("data", "voices")
+	VIDEO_PATH = path.Join("data", "videos")
 
-var VOICE_PATH = path.Join("data", "voices")
-
-var VIDEO_PATH = path.Join("data", "videos")
+	HEADER_AMR  = []byte("#!AMR")
+	HEADER_SILK = []byte("\x02#!SILK_V3")
+)
 
 func PathExists(path string) bool {
 	_, err := os.Stat(path)
@@ -37,8 +42,5 @@ func Check(err error) {
 }
 
 func IsAMR(b []byte) bool {
-	if len(b) <= 6 {
-		return false
-	}
-	return b[0] == 0x23 && b[1] == 0x21 && b[2] == 0x41 && b[3] == 0x4D && b[4] == 0x52 // amr file header
+	return bytes.HasPrefix(b, HEADER_AMR) || bytes.HasPrefix(b, HEADER_SILK)
 }


### PR DESCRIPTION
试了一下，`data/voices` 中接收到的文件虽然扩展名是 amr，但实际格式是 silk。
这里对文件头做了限制发不出去，放开此限制后可以发送出去。