### PR TITLE
fix get_msg response payload

### DIFF
--- a/coolq/api.go
+++ b/coolq/api.go
@@ -662,7 +662,7 @@ func (bot *CQBot) CQGetMessage(messageId int32) MSG {
 			"nickname": sender.Nickname,
 		},
 		"time":    msg["time"],
-		"content": msg["message"],
+		"message": msg["message"],
 	})
 }
 


### PR DESCRIPTION
修改了与标准不符的字段。

https://github.com/howmanybots/onebot/blob/master/v11/specs/api/public.md#send_msg-%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF