### PR TITLE
remove mkdir, add set -ex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM golang:1.15.5-alpine AS builder
 
 RUN go env -w GO111MODULE=auto \
   && go env -w CGO_ENABLED=0 \
-  && go env -w GOPROXY=https://goproxy.cn,direct \
-  && mkdir /build
+  && go env -w GOPROXY=https://goproxy.cn,direct 
 
 WORKDIR /build
 
 COPY ./ .
 
-RUN cd /build \
-  && go build -ldflags "-s -w -extldflags '-static'" -o cqhttp
+RUN set -ex \
+    && cd /build \
+    && go build -ldflags "-s -w -extldflags '-static'" -o cqhttp
 
 FROM alpine:latest
 


### PR DESCRIPTION
1. 根据 [Docker文档](https://docs.docker.com/engine/reference/builder/#workdir) 里的描述，`WORKDIR` 指令在目录不存在时会自动创建，因此没必要在 `WORKDIR /build` 之前执行 `mkdir /build`

2. 执行 bash 脚本之前最好加上 `set -ex`，因为脚本执行过程中可能会出错，`-e` 在出错时会立即退出， `-x` 会打印出错误调用栈
[GNU手册](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)

3. `docker build . -t mrs4s/go-cqhttp:v0.x` 创建镜像没啥问题
![image](https://user-images.githubusercontent.com/8622915/100539419-49748b80-3271-11eb-84fc-5f85a6b66693.png)




