### PR TITLE
Make send_group_forward_msg can use on get_msg

### DIFF
--- a/coolq/api.go
+++ b/coolq/api.go
@@ -343,7 +343,7 @@ func (bot *CQBot) CQSendGroupForwardMessage(groupId int64, m gjson.Result) MSG {
 	if len(sendNodes) > 0 {
 		gm := bot.Client.SendGroupForwardMessage(groupId, &message.ForwardMessage{Nodes: sendNodes})
 		return OK(MSG{
-			"message_id": ToGlobalId(groupId, gm.Id),
+			"message_id": bot.InsertGroupMessage(gm),
 		})
 	}
 	return Failed(100)


### PR DESCRIPTION
Fix https://github.com/Mrs4s/go-cqhttp/issues/542

理论上这个是正常支持的