### PR TITLE
去掉无用的登录错误提示

### DIFF
--- a/server/apiAdmin.go
+++ b/server/apiAdmin.go
@@ -148,7 +148,6 @@ func (s *webServer) logincore(relogin bool) {
 		} else if err == client.ErrAlreadyOnline {
 			break
 		}
-		log.Error("登录遇到错误: " + err.Error())
 
 		switch res.Error {
 		case client.SliderNeededError:


### PR DESCRIPTION
这个提示应该没啥用 新账号登录的时候需要验证 返回的err是nil会导致null pointer dereference
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x18 pc=0xc7069c]

goroutine 1 [running]:
github.com/Mrs4s/go-cqhttp/server.(*webServer).logincore(0x1755d80, 0x0)
        C:/Users/Tony/Downloads/go-cqhttp-dev/server/apiAdmin.go:153 +0x1c1c
github.com/Mrs4s/go-cqhttp/server.(*webServer).Dologin(0x1755d80)
        C:/Users/Tony/Downloads/go-cqhttp-dev/server/apiAdmin.go:320 +0x57
github.com/Mrs4s/go-cqhttp/server.(*webServer).Run(0x1755d80, 0xc000542820, 0xe, 0xc00041f400, 0x2)
        C:/Users/Tony/Downloads/go-cqhttp-dev/server/apiAdmin.go:114 +0x229
main.main()
        C:/Users/Tony/Downloads/go-cqhttp-dev/main.go:281 +0xac3
```