### PR TITLE
Accelerate cqcode again！

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           if $IS_PR ; then echo $PR_PROMPT; fi
           export BINARY_NAME="$BINARY_PREFIX$GOOS_$GOARCH$BINARY_SUFFIX"
           export CGO_ENABLED=0
-          go build -o "output/$BINARY_NAME" -ldflags "$LD_FLAGS" .
+          go build -o "output/$BINARY_NAME" -trimpath -ldflags "$LD_FLAGS" .
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         if: ${{ !github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,6 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: "https://golang.org/dl/go1.16.linux-amd64.tar.gz"
+          build_flags: -trimpath
           ldflags: -w -s -X "github.com/Mrs4s/go-cqhttp/coolq.Version=${{ env.RELEASE_VERSION }}"
           

--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -359,7 +359,7 @@ func ToStringMessage(e []message.IMessageElement, id int64, isRaw ...bool) (r st
 // ConvertStringMessage 将消息字符串转为消息元素数组
 func (bot *CQBot) ConvertStringMessage(s string, isGroup bool) (r []message.IMessageElement) {
 	var t, key string
-	var d map[string]string
+	var d = map[string]string{}
 	ptr := unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&s)).Data)
 	l := len(s)
 	i, j, CQBegin := 0, 0, 0
@@ -448,7 +448,9 @@ S1: // Plain Text
 	}
 	goto End
 S2: // CQCode Type
-	d = make(map[string]string)
+	for k := range d { // 内存复用，减小GC压力
+		delete(d, k)
+	}
 	for ; i < l; i++ {
 		switch *(*byte)(add(ptr, uintptr(i))) {
 		case ',': // CQ Code with params


### PR DESCRIPTION
BenchmarkCQBot_ConvertStringMessage-8 232700 4743 ns/op 2672 B/op 65 allocs/op
BenchmarkCQBot_ConvertStringMessage2-8 752025 1643 ns/op 1376 B/op 17 allocs/op

经过小优化后:

BenchmarkCQBot_ConvertStringMessage-8             963939              1205 ns/op             368 B/op         11 allocs/op

ci中使用-trimpath，能减小1k的体积