### PR TITLE
一堆修改

### DIFF
--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -397,9 +397,10 @@ func (bot *CQBot) ConvertStringMessage(s string, isGroup bool) (r []message.IMes
 				if err != nil {
 					msgTime = time.Now().Unix()
 				}
+				messageSeq, _ := strconv.ParseInt(d["seq"], 10, 64)
 				r = append([]message.IMessageElement{
 					&message.ReplyElement{
-						ReplySeq: int32(0),
+						ReplySeq: int32(messageSeq),
 						Sender:   sender,
 						Time:     int32(msgTime),
 						Elements: bot.ConvertStringMessage(customText, isGroup),
@@ -530,16 +531,17 @@ func (bot *CQBot) ConvertObjectMessage(m gjson.Result, isGroup bool) (r []messag
 			} else if customText != "" {
 				sender, err := strconv.ParseInt(e.Get("data").Get("qq").String(), 10, 64)
 				if err != nil {
-					log.Warnf("警告:自定义 Reply 元素中必须包含Uin")
+					log.Warnf("警告:自定义 Reply 元素中必须包含 Uin")
 					return
 				}
 				msgTime, err := strconv.ParseInt(e.Get("data").Get("time").String(), 10, 64)
 				if err != nil {
 					msgTime = time.Now().Unix()
 				}
+				messageSeq, _ := strconv.ParseInt(e.Get("data").Get("seq").String(), 10, 64)
 				r = append([]message.IMessageElement{
 					&message.ReplyElement{
-						ReplySeq: int32(0),
+						ReplySeq: int32(messageSeq),
 						Sender:   sender,
 						Time:     int32(msgTime),
 						Elements: bot.ConvertStringMessage(customText, isGroup),

--- a/docs/cqhttp.md
+++ b/docs/cqhttp.md
@@ -111,12 +111,12 @@ Type : `reply`
 | `text` | string | 自定义回复的信息                                    |
 | `qq`   | int64  | 自定义回复时的自定义QQ, 如果使用自定义信息必须指定. |
 | `time` | int64  | 可选. 自定义回复时的时间, 格式为Unix时间 |
-
+| `seq` | int64  | 可选. 自定义信息原始ID |
 
 
 示例: `[CQ:reply,id=123456]` 
 \
-自定义回复示例: `[CQ:reply,text=Hello World,qq=10086,time=3376656000]`
+自定义回复示例: `[CQ:reply,text=Hello World,qq=10086,time=3376656000,seq=5123]`
 
 ### 音乐分享 <Badge text="发"/>
 
@@ -263,8 +263,9 @@ Type: `node`
 | `name`    | string  | 发送者显示名字 | 用于自定义消息 (自定义消息并合并转发，实际查看顺序为自定义消息段顺序)                  |
 | `uin`     | int64   | 发送者QQ号     | 用于自定义消息                                                                         |
 | `content` | message | 具体消息       | 用于自定义消息                                                                         |
+| `seq`     | message | 具体消息       | 用于自定义消息                                                                         |
 
-特殊说明: **需要使用单独的API `/send_group_forward_msg` 发送，并且由于消息段较为复杂，仅支持Array形式入参。 如果引用消息和自定义消息同时出现，实际查看顺序将取消息段顺序.  另外按 [CQHTTP](https://cqhttp.cc/docs/4.15/#/Message?id=格式) 文档说明, `data` 应全为字符串, 但由于需要接收`message` 类型的消息, 所以 *仅限此Type的content字段* 支持Array套娃**
+特殊说明: **需要使用单独的API `/send_group_forward_msg` 发送，并且由于消息段较为复杂，仅支持Array形式入参。 如果引用消息和自定义消息同时出现，实际查看顺序将取消息段顺序.  另外按 [CQHTTP](https://git.io/JtxtN) 文档说明, `data` 应全为字符串, 但由于需要接收`message` 类型的消息, 所以 *仅限此Type的content字段* 支持Array套娃**
 
 示例: 
 
@@ -325,6 +326,7 @@ Type: `node`
             "name": "自定义发送者",
             "uin": "10086",
             "content": "我是自定义消息",
+            "seq": "5123",
             "time": "3376656000"
         }
     },

--- a/server/api.go
+++ b/server/api.go
@@ -74,7 +74,13 @@ func sendPrivateMSG(bot *coolq.CQBot, p resultGetter) coolq.MSG {
 }
 
 func deleteMSG(bot *coolq.CQBot, p resultGetter) coolq.MSG {
-	return bot.CQDeleteMessage(int32(p.Get("message_id").Int()))
+	messageSeq := int32(p.Get("message_seq").Int())
+	internalId := int32(p.Get("internal_id").Int())
+	groupId := p.Get("group_id").Int()
+	if messageSeq != 0 && internalId != 0 && groupId != 0 {
+		return bot.CQDeleteMessage(messageSeq, internalId, groupId)
+	}
+	return bot.CQDeleteMessage(int32(p.Get("message_id").Int()), 0, 0)
 }
 
 func setFriendAddRequest(bot *coolq.CQBot, p resultGetter) coolq.MSG {


### PR DESCRIPTION
- 为send_private_msg, send_group_msg, send_group_forward_msg 添加group_id/user_id, message_seq和internal_id(内部ID, 无任何详细说明)
- 注: 临时信息的internal_id为0 (无法撤回)
- set_group_ban 可以禁言的时长添加到2592000秒(之前为2591999, 因为用了">=")
- .handle_quick_operation, delete_msg 可以使用group_id和message_seq进行操作(避免信息必须在数据库的问题)
- delete_msg 可以用 group_id 和 message_seq (如果是群信息)
- 为CQ的reply添加了seq选项
- 更新文档