### PR TITLE
Repair: 获取群信息却返回了群列表

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -30,7 +30,7 @@ func getGroupList(bot *coolq.CQBot, p resultGetter) coolq.MSG {
 }
 
 func getGroupInfo(bot *coolq.CQBot, p resultGetter) coolq.MSG {
-	return bot.CQGetGroupList(p.Get("no_cache").Bool())
+	return bot.CQGetGroupInfo(p.Get("group_id").Int(), p.Get("no_cache").Bool())
 }
 
 func getGroupMemberList(bot *coolq.CQBot, p resultGetter) coolq.MSG {


### PR DESCRIPTION
试图通过 get_group_info 获取某个群的信息却返回了机器人所加群的列表