### PR TITLE
修复bug&更正代码

### DIFF
--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -390,16 +390,20 @@ func (bot *CQBot) ConvertStringMessage(s string, isGroup bool) (r []message.IMes
 			} else if customText != "" {
 				sender, err := strconv.ParseInt(d["qq"], 10, 64)
 				if err != nil {
-					log.Warnf("警告:自定义 Reply 元素中必须包含Uin")
+					log.Warnf("警告:自定义 Reply 元素中必须包含 Uin")
 					return
 				}
 				msgTime, err := strconv.ParseInt(d["time"], 10, 64)
 				if err != nil {
 					msgTime = time.Now().Unix()
 				}
+				messageSeq, err := strconv.ParseInt(d["seq"], 10, 64)
+				if err != nil {
+					messageSeq = 0
+				}
 				r = append([]message.IMessageElement{
 					&message.ReplyElement{
-						ReplySeq: int32(0),
+						ReplySeq: int32(messageSeq),
 						Sender:   sender,
 						Time:     int32(msgTime),
 						Elements: bot.ConvertStringMessage(customText, isGroup),
@@ -530,16 +534,20 @@ func (bot *CQBot) ConvertObjectMessage(m gjson.Result, isGroup bool) (r []messag
 			} else if customText != "" {
 				sender, err := strconv.ParseInt(e.Get("data").Get("qq").String(), 10, 64)
 				if err != nil {
-					log.Warnf("警告:自定义 Reply 元素中必须包含Uin")
+					log.Warnf("警告:自定义 Reply 元素中必须包含 Uin")
 					return
 				}
 				msgTime, err := strconv.ParseInt(e.Get("data").Get("time").String(), 10, 64)
 				if err != nil {
 					msgTime = time.Now().Unix()
 				}
+				messageSeq, err := strconv.ParseInt(e.Get("data").Get("seq").String(), 10, 64)
+				if err != nil {
+					messageSeq = 0
+				}
 				r = append([]message.IMessageElement{
 					&message.ReplyElement{
-						ReplySeq: int32(0),
+						ReplySeq: int32(messageSeq),
 						Sender:   sender,
 						Time:     int32(msgTime),
 						Elements: bot.ConvertStringMessage(customText, isGroup),

--- a/coolq/event.go
+++ b/coolq/event.go
@@ -103,16 +103,20 @@ func (bot *CQBot) groupMessageEvent(c *client.QQClient, m *message.GroupMessage)
 
 func (bot *CQBot) tempMessageEvent(c *client.QQClient, m *message.TempMessage) {
 	bot.checkMedia(m.Elements)
-	cqm := ToStringMessage(m.Elements, 0, true)
+	cqm := ToStringMessage(m.Elements, m.Sender.Uin, true)
 	bot.tempMsgCache.Store(m.Sender.Uin, m.GroupCode)
+	id := m.Id
+	if bot.db != nil {
+		id = bot.InsertTempMessage(m.Sender.Uin, m)
+	}
 	log.Infof("收到来自群 %v(%v) 内 %v(%v) 的临时会话消息: %v", m.GroupName, m.GroupCode, m.Sender.DisplayName(), m.Sender.Uin, cqm)
 	tm := MSG{
 		"post_type":    "message",
 		"message_type": "private",
 		"sub_type":     "group",
-		"message_id":   m.Id,
+		"message_id":   id,
 		"user_id":      m.Sender.Uin,
-		"message":      ToFormattedMessage(m.Elements, 0, false),
+		"message":      ToFormattedMessage(m.Elements, m.Sender.Uin, false),
 		"raw_message":  cqm,
 		"font":         0,
 		"self_id":      c.Uin,

--- a/docs/cqhttp.md
+++ b/docs/cqhttp.md
@@ -111,12 +111,13 @@ Type : `reply`
 | `text` | string | 自定义回复的信息                                    |
 | `qq`   | int64  | 自定义回复时的自定义QQ, 如果使用自定义信息必须指定. |
 | `time` | int64  | 可选. 自定义回复时的时间, 格式为Unix时间 |
+| `seq` | int64  | 起始消息序号, 可通过 `get_msg` 获得 |
 
 
 
 示例: `[CQ:reply,id=123456]` 
 \
-自定义回复示例: `[CQ:reply,text=Hello World,qq=10086,time=3376656000]`
+自定义回复示例: `[CQ:reply,text=Hello World,qq=10086,time=3376656000,seq=5123]`
 
 ### 音乐分享 <Badge text="发"/>
 
@@ -263,8 +264,9 @@ Type: `node`
 | `name`    | string  | 发送者显示名字 | 用于自定义消息 (自定义消息并合并转发，实际查看顺序为自定义消息段顺序)                  |
 | `uin`     | int64   | 发送者QQ号     | 用于自定义消息                                                                         |
 | `content` | message | 具体消息       | 用于自定义消息                                                                         |
+| `seq`     | message | 具体消息       | 用于自定义消息                                                                         |
 
-特殊说明: **需要使用单独的API `/send_group_forward_msg` 发送，并且由于消息段较为复杂，仅支持Array形式入参。 如果引用消息和自定义消息同时出现，实际查看顺序将取消息段顺序.  另外按 [CQHTTP](https://cqhttp.cc/docs/4.15/#/Message?id=格式) 文档说明, `data` 应全为字符串, 但由于需要接收`message` 类型的消息, 所以 *仅限此Type的content字段* 支持Array套娃**
+特殊说明: **需要使用单独的API `/send_group_forward_msg` 发送，并且由于消息段较为复杂，仅支持Array形式入参。 如果引用消息和自定义消息同时出现，实际查看顺序将取消息段顺序.  另外按 [CQHTTP](https://git.io/JtxtN) 文档说明, `data` 应全为字符串, 但由于需要接收`message` 类型的消息, 所以 *仅限此Type的content字段* 支持Array套娃**
 
 示例: 
 
@@ -325,6 +327,7 @@ Type: `node`
             "name": "自定义发送者",
             "uin": "10086",
             "content": "我是自定义消息",
+            "seq": "5123",
             "time": "3376656000"
         }
     },
@@ -603,10 +606,10 @@ Type: `tts`
 | 字段       | 类型           | 说明                         |
 | ---------- | -------------- | ---------------------------- |
 | `group_id` | int64          | 群号                         |
-| `messages` | forward node[] | 自定义转发消息, 具体看CQCode |
+| `messages` | forward node[] | 自定义转发消息, 具体看 [CQCode](https://github.com/Mrs4s/go-cqhttp/blob/master/docs/cqhttp.md#%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91%E6%B6%88%E6%81%AF%E8%8A%82%E7%82%B9) |
 
 响应数据
-
+    
 | 字段         | 类型   | 说明   |
 | ------------ | ------ | ------ |
 | `message_id` | string | 消息id |


### PR DESCRIPTION
> Commit里面的信息已经进行分类，方便查看
- `SendGroupForwardMessage` 添加发送失败Handler
- 禁言逻辑修复, 可以进行30(整)天的禁言
- 添加无法撤回临时信息Handling
- 临时会话中的变量改名 (code -> groupId)
- 临时会话发送与接收信息入库 (唯独没法加InternalId)
- 警告信息添加空格 (见cqcode.go)
- 为自定义reply添加seq选项以加真实性
- 更新文档: 添加seq说明, 缩短某个网址, 添加某个`CQcode`定义的导向
- 修复好友被删除后的处理 #374 