### PR TITLE
chore(dep): Upgrade go from 1.15.5 to 1.16 in dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.5-alpine AS builder
+FROM golang:1.16-alpine AS builder
 
 RUN go env -w GO111MODULE=auto \
   && go env -w CGO_ENABLED=0 \


### PR DESCRIPTION
io.ReadAll in global/update/update_others.go requiring go version >= 1.16, upgrade builder version in dockerfile to fix docker image build.