### PR TITLE
[WIP] 添加群视频通话

### DIFF
--- a/coolq/api.go
+++ b/coolq/api.go
@@ -1279,6 +1279,20 @@ func (bot *CQBot) CQCheckURLSafely(url string) MSG {
 	})
 }
 
+// CQStartGroupVideo 扩展API-开始群视频通话
+//
+//
+func (bot *CQBot) CQStartGroupVideo(groupCode int64) MSG {
+	return OK(MSG{})
+}
+
+// CQStopGroupVideo 扩展API-关闭群视频通话
+//
+//
+func (bot *CQBot) CQStopGroupVideo(groupCode int64) MSG {
+	return OK(MSG{})
+}
+
 // CQGetVersionInfo 获取版本信息
 //
 // https://git.io/JtwUs

--- a/server/api.go
+++ b/server/api.go
@@ -303,6 +303,14 @@ func checkURLSafely(bot *coolq.CQBot, p resultGetter) coolq.MSG {
 	return bot.CQCheckURLSafely(p.Get("url").String())
 }
 
+func startGroupVideo(bot *coolq.CQBot, p resultGetter) coolq.MSG {
+	return bot.CQStartGroupVideo(p.Get("group_code").Int())
+}
+
+func stopGroupVideo(bot *coolq.CQBot, p resultGetter) coolq.MSG {
+	return bot.CQStartGroupVideo(p.Get("group_code").Int())
+}
+
 func setGroupAnonymousBan(bot *coolq.CQBot, p resultGetter) coolq.MSG {
 	obj := p.Get("anonymous")
 	flag := p.Get("anonymous_flag")
@@ -376,6 +384,8 @@ var API = map[string]func(*coolq.CQBot, resultGetter) coolq.MSG{
 	"delete_essence_msg":         deleteEssenceMSG,
 	"get_essence_msg_list":       getEssenceMsgList,
 	"check_url_safely":           checkURLSafely,
+	"start_group_video":          startGroupVideo,
+	"stop_group_video":           stopGroupVideo,
 	"set_group_anonymous_ban":    setGroupAnonymousBan,
 	".handle_quick_operation":    handleQuickOperation,
 }


### PR DESCRIPTION
**需要添加的功能内容**
添加主动开启群视频功能, 并可以直播
但不打算添加获取直播链接或类似的功能

注: 我自用的, 但为了避免麻烦(指上游更新)就Pull Request了

_如果有人因为这个功能而开 issue 我将全盘负责
但将会以**最低优先度**处理, 
一个人的效率禁止抱怨_

**预计添加的API**
- [ ] `start_group_video` 开始群视频通话
... (+_unknown_ more)
- [ ] `stop_group_video` 结束群视频通话

**预计添加的Event**
- [ ] 群视频通话开始
- [ ] 群视频通话结束

**额外资料**
(有待实现验证) 已知一个账号可以在多个群同时通话 (全用的安卓, iPad, 电脑测试, 单个账号多开没问题)

~oidb_0x899 (群成员列表?????)~
VideoChannelServlet (From qav.channel)

tencent.av.v2q.StartVideoChat
tencent.av.v2q.StopVideoChat

tencent.video.v2q.*
getGatewayIp (获取IP吗?)
看logcat, 可能是发送UDP跑到服务器

~快看, Sam又开始画饼了~