### PR TITLE
使用stdout来输出日志

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,8 @@ func init() {
 		TimestampFormat: "2006-01-02 15:04:05",
 		LogFormat:       "[%time%] [%lvl%]: %msg% \n",
 	}
-
+	log.SetOutput(os.Stdout)
+	
 	w, err := rotatelogs.New(path.Join("logs", "%Y-%m-%d.log"), rotatelogs.WithRotationTime(time.Hour*24))
 	if err != nil {
 		log.Errorf("rotatelogs init err: %v", err)


### PR DESCRIPTION
使用stdout代替默认的stderr来输出日志避免在一些进程管理工具中造成困扰和不便