### PR TITLE
修改 README 中的几处拼写细节

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ go-cqhttp兼容[OneBot-v11](https://github.com/howmanybots/onebot/tree/master/v1
 
 - [x] HTTP API
 - [x] 反向 HTTP POST
-- [x] 正向 Websocket
-- [x] 反向 Websocket
+- [x] 正向 WebSocket
+- [x] 反向 WebSocket
 
 ### 拓展支持
 
@@ -70,7 +70,7 @@ go-cqhttp兼容[OneBot-v11](https://github.com/howmanybots/onebot/tree/master/v1
 <details>
 <summary>已实现CQ码</summary>
 
-#### 符合 Onebot 标准的 CQ 码
+#### 符合 OneBot 标准的 CQ 码
 
 | CQ 码        | 功能                        |
 | ------------ | --------------------------- |
@@ -99,7 +99,7 @@ go-cqhttp兼容[OneBot-v11](https://github.com/howmanybots/onebot/tree/master/v1
 [xml 消息]: https://github.com/howmanybots/onebot/blob/master/v11/specs/message/segment.md#xml-%E6%B6%88%E6%81%AF
 [json 消息]: https://github.com/howmanybots/onebot/blob/master/v11/specs/message/segment.md#json-%E6%B6%88%E6%81%AF
 
-#### 拓展 CQ 码及与 Onebot 标准有略微差异的 CQ 码
+#### 拓展 CQ 码及与 OneBot 标准有略微差异的 CQ 码
 
 | 拓展 CQ 码     | 功能                              |
 | -------------- | --------------------------------- |
@@ -124,7 +124,7 @@ go-cqhttp兼容[OneBot-v11](https://github.com/howmanybots/onebot/tree/master/v1
 <details>
 <summary>已实现API</summary>
 
-#### 符合 Onebot 标准的 API
+#### 符合 OneBot 标准的 API
 
 | API                      | 功能                   |
 | ------------------------ | ---------------------- |
@@ -184,7 +184,7 @@ go-cqhttp兼容[OneBot-v11](https://github.com/howmanybots/onebot/tree/master/v1
 [重启 go-cqhttp]: https://github.com/howmanybots/onebot/blob/master/v11/specs/api/public.md#set_restart-%E9%87%8D%E5%90%AF-onebot-%E5%AE%9E%E7%8E%B0
 [对事件执行快速操作]: https://github.com/howmanybots/onebot/blob/master/v11/specs/api/hidden.md#handle_quick_operation-%E5%AF%B9%E4%BA%8B%E4%BB%B6%E6%89%A7%E8%A1%8C%E5%BF%AB%E9%80%9F%E6%93%8D%E4%BD%9C
 
-#### 拓展 API 及与 Onebot 标准有略微差异的 API
+#### 拓展 API 及与 OneBot 标准有略微差异的 API
 
 | 拓展 API                    | 功能                   |
 | --------------------------- | ---------------------- |
@@ -221,7 +221,7 @@ go-cqhttp兼容[OneBot-v11](https://github.com/howmanybots/onebot/tree/master/v1
 <details>
 <summary>已实现Event</summary>
 
-#### 符合 Onebot 标准的 Event（部分 Event 比 Onebot 标准多上报几个字段，不影响使用）
+#### 符合 OneBot 标准的 Event（部分 Event 比 OneBot 标准多上报几个字段，不影响使用）
 
 | 事件类型 | Event            |
 | -------- | ---------------- |


### PR DESCRIPTION
根据标准将 WebSocket 和 OneBot 中间的字母改为大写。