### PR TITLE
feat: auto build and push docker image to ghcr (and optional dockerhu…

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,78 @@
+name: Build And Push Docker Image
+
+on:
+  push:
+    branches:
+      - 'master'
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  schedule:
+    # 每晚十点生成 nightly 镜像
+    - cron: '00 14 * * *' # GMT 14:00 => 北京时间 22:00
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set time zone
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Asia/Shanghai"
+          timezoneMacos: "Asia/Shanghai"
+          timezoneWindows: "China Standard Time"
+
+      # # 如果有 dockerhub 账户，可以在github的secrets中配置下面两个，然后取消下面注释的这几行，并在meta步骤的images增加一行 ${{ github.repository }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          #   nightly, master, pr-2, 1.2.3, 1.2, 1
+          tags: |
+            type=schedule,pattern=nightly
+            type=edge
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
可以利用github的actions功能在以下情况自动构建docker镜像并发布到若干个镜像仓库，比如ghcr.io，方便其他人直接pull
1. push到主干
2. release新版本v*
3. nightly

如果有dockerhub账号，可以把登录dockerhub和设置tags的相应部分取消注释，然后在github账户的secrets中设置好对应账号和密码即可

大致效果如下（我的另一个仓库的packages）

<img width="778" alt="Snipaste_2021-10-05_00-23-09" src="https://user-images.githubusercontent.com/13483212/135888267-e4ee8702-0baa-4106-a0a3-012f7d20fe19.png">

<img width="831" alt="Snipaste_2021-10-05_00-18-03" src="https://user-images.githubusercontent.com/13483212/135888295-ffbf069c-7b2b-42c1-bcc4-3ef64266d2bc.png">

<img width="1071" alt="Snipaste_2021-10-05_00-22-23" src="https://user-images.githubusercontent.com/13483212/135888307-914e1e15-b005-4983-a507-8d135f467bd7.png">
