### PR TITLE
fix: 当从 url 获取图片失败时，返回失败，而不是成功

### DIFF
--- a/coolq/api.go
+++ b/coolq/api.go
@@ -1057,7 +1057,7 @@ func (bot *CQBot) CQGetImage(file string) global.MSG {
 				_ = body.Close()
 				f.Close()
 			} else {
-				log.Warnf("下载图片 %v 时出现错误", msg["url"], err)
+				log.Warnf("下载图片 %v 时出现错误: %v", msg["url"], err)
 				return Failed(100, "DOWNLOAD_IMAGE_ERROR", err.Error())
 			}
 		}


### PR DESCRIPTION
fix: return error when get_image from url failed