### PR TITLE
修正 HTTP POST 内容类型为 json

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -239,6 +239,7 @@ func (c *HTTPClient) onBotPushEvent(e *coolq.Event) {
 	req, _ := http.NewRequest("POST", c.addr, bytes.NewReader(e.JSONBytes()))
 	req.Header.Set("X-Self-ID", strconv.FormatInt(c.bot.Client.Uin, 10))
 	req.Header.Set("User-Agent", "CQHttp/4.15.0")
+	req.Header.Set("Content-Type", "application/json")
 	if c.secret != "" {
 		mac := hmac.New(sha1.New, []byte(c.secret))
 		_, _ = mac.Write(e.JSONBytes())


### PR DESCRIPTION
beta7 版本时，HTTP POST 的数据内容类型为 [json](https://github.com/Mrs4s/go-cqhttp/blob/60d5f4d3869667a4771189c2e6a40720c0a67bbd/server/http.go#L223)