### PR TITLE
Fix image..jpg

### DIFF
--- a/coolq/api.go
+++ b/coolq/api.go
@@ -1346,7 +1346,7 @@ func (bot *CQBot) CQGetImage(file string) global.MSG {
 			"filename": r.ReadString(),
 			"url":      r.ReadString(),
 		}
-		local := path.Join(global.CachePath, file+"."+path.Ext(msg["filename"].(string)))
+		local := path.Join(global.CachePath, file+path.Ext(msg["filename"].(string)))
 		if !global.PathExists(local) {
 			if body, err := global.HTTPGetReadCloser(msg["url"].(string)); err == nil {
 				f, _ := os.OpenFile(local, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o0644)


### PR DESCRIPTION
`path.Ext()` 的返回值里面已经有点了，现在我目录里缓存了好多 `*.image..jpg` 的文件…