### PR TITLE
fix(expand env): change os.ExpandEnv to regex

### DIFF
--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -184,8 +184,11 @@ func generateConfig() {
 	_, _ = input.ReadString('\n')
 }
 
+// expand 使用正则进行环境变量展开
+// os.ExpandEnv 字符 $ 无法逃逸
+// https://github.com/golang/go/issues/43482
 func expand(s string, mapping func(string) string) string {
-	r := regexp.MustCompile(`\${(.*?)}`)
+	r := regexp.MustCompile(`\${([a-zA-Z_]+[a-zA-Z0-9_]*)}`)
 	re := r.FindAllStringSubmatch(s, -1)
 	for _, i := range re {
 		if len(i) == 2 {

--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -185,10 +185,7 @@ func generateConfig() {
 }
 
 func expand(s string, mapping func(string) string) string {
-	r, err := regexp.Compile(`\${(.*?)}`)
-	if err != nil {
-		return s
-	}
+	r := regexp.MustCompile(`\${(.*?)}`)
 	re := r.FindAllStringSubmatch(s, -1)
 	for _, i := range re {
 		if len(i) == 2 {


### PR DESCRIPTION
由于`os.ExpandEnv`会解析`$`且无法转义，导致配置文件中包含`$`的值无法正常被解析
使用regex写的一个expand替换掉`os.ExpandEnv`