### PR TITLE
fix: should not use faststart flag before parse it

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -43,14 +43,6 @@ var allowStatus = [...]client.UserOnlineStatus{
 // Main 启动主程序
 func Main() {
 	base.Parse()
-	if !base.FastStart && terminal.RunningByDoubleClick() {
-		err := terminal.NoMoreDoubleClick()
-		if err != nil {
-			log.Errorf("遇到错误: %v", err)
-			time.Sleep(time.Second * 5)
-		}
-		return
-	}
 	switch {
 	case base.LittleH:
 		base.Help()
@@ -118,6 +110,14 @@ func Main() {
 				base.FastStart = true
 			}
 		}
+	}
+	if !base.FastStart && terminal.RunningByDoubleClick() {
+		err := terminal.NoMoreDoubleClick()
+		if err != nil {
+			log.Errorf("遇到错误: %v", err)
+			time.Sleep(time.Second * 5)
+		}
+		return
 	}
 
 	if (base.Account.Uin == 0 || (base.Account.Password == "" && !base.Account.Encrypt)) && !global.PathExists("session.token") {

--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -43,6 +43,14 @@ var allowStatus = [...]client.UserOnlineStatus{
 // Main 启动主程序
 func Main() {
 	base.Parse()
+	if !base.FastStart && terminal.RunningByDoubleClick() {
+		err := terminal.NoMoreDoubleClick()
+		if err != nil {
+			log.Errorf("遇到错误: %v", err)
+			time.Sleep(time.Second * 5)
+		}
+		return
+	}
 	switch {
 	case base.LittleH:
 		base.Help()
@@ -106,18 +114,8 @@ func Main() {
 					byteKey = []byte(arg[p])
 					para.Hide(p)
 				}
-			case "faststart":
-				base.FastStart = true
 			}
 		}
-	}
-	if !base.FastStart && terminal.RunningByDoubleClick() {
-		err := terminal.NoMoreDoubleClick()
-		if err != nil {
-			log.Errorf("遇到错误: %v", err)
-			time.Sleep(time.Second * 5)
-		}
-		return
 	}
 
 	if (base.Account.Uin == 0 || (base.Account.Password == "" && !base.Account.Encrypt)) && !global.PathExists("session.token") {

--- a/internal/base/flag.go
+++ b/internal/base/flag.go
@@ -68,6 +68,16 @@ func Parse() {
 	if *d {
 		Debug = true
 	}
+
+	// 在检查windows双击之前解析 faststart 标记
+	arg := os.Args
+	if len(arg) > 1 {
+		for i := range arg {
+			if arg[i] == "faststart" {
+				FastStart = true
+			}
+		}
+	}
 }
 
 // Init read config from yml file


### PR DESCRIPTION
目前设计上仅在未设置FastStart标记时，才会检查RunningByDoubleClick。
https://github.com/Mrs4s/go-cqhttp/blob/7278f99ed9118fe2e54aca752e62574d5bae3f00/cmd/gocq/main.go#L46-L53

但是由于目前代码中实际上在更后面的地方才解析FastStart标记，会导致这里这个判断永远没有作用。
https://github.com/Mrs4s/go-cqhttp/blob/7278f99ed9118fe2e54aca752e62574d5bae3f00/cmd/gocq/main.go#L117-L118

pr中将这段逻辑移到了解析的地方之后，也可以选择把解析FastStart的代码往前移