### PR TITLE
更新 633 链接

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -11,7 +11,7 @@ body:
         ## 感谢您愿意填写错误回报！
         ## 以下是一些注意事项，请务必阅读让我们能够更容易处理
 
-        ### ❗ | 确定没有相同问题的ISSUE已被提出. (教程: https://github.com/Mrs4s/go-cqhttp/issues/633)
+        ### ❗ | 确定没有相同问题的ISSUE已被提出. (教程: https://forums.go-cqhttp.org/t/topic/141)
         ### 🌎| 请准确填写环境信息
         ### ❔ | 打开DEBUG模式复现，并提供出现问题前后至少 10 秒的完整日志内容。请自行删除日志内存在的个人信息及敏感内容。
         ### ⚠ | 如果涉及内存泄漏/CPU占用异常请打开DEBUG模式并下载pprof性能分析.
@@ -24,7 +24,7 @@ body:
     attributes:
       label: 请确保您已阅读以上注意事项，并勾选下方的确认框。
       options:
-        - label: "我已经仔细阅读上述教程和 [\"提问前需知\"](https://github.com/Mrs4s/go-cqhttp/issues/633)"
+        - label: "我已经仔细阅读上述教程和 [\"提问前需知\"](https://forums.go-cqhttp.org/t/topic/141)"
           required: true
         - label: "我已经使用 [dev分支版本](https://github.com/Mrs4s/go-cqhttp/actions/workflows/ci.yml) 测试过，问题依旧存在。"
           required: true


### PR DESCRIPTION
由于 github 已删除原 #633 issue，我使用了特殊手段恢复了原本的内容并移动到了论坛里
现在可以透过 <https://forums.go-cqhttp.org/t/topic/141> 来查看原内容