### PR TITLE
fix: data文件夹权限问题

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -81,7 +81,7 @@ func Main() {
 
 	mkCacheDir := func(path string, _type string) {
 		if !global.PathExists(path) {
-			if err := os.MkdirAll(path, 0o744); err != nil {
+			if err := os.MkdirAll(path, 0o755); err != nil {
 				log.Fatalf("创建%s缓存文件夹失败: %v", _type, err)
 			}
 		}

--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -81,7 +81,7 @@ func Main() {
 
 	mkCacheDir := func(path string, _type string) {
 		if !global.PathExists(path) {
-			if err := os.MkdirAll(path, 0o644); err != nil {
+			if err := os.MkdirAll(path, 0o744); err != nil {
 				log.Fatalf("创建%s缓存文件夹失败: %v", _type, err)
 			}
 		}


### PR DESCRIPTION
当权限644时候，data文件夹会由于没有执行权限而无法创建后续的图片...等一系列文件夹。