### PR TITLE
fix a bug 使用mongodb时 image的 subtype会被存储为NumberLong类型

### DIFF
--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -733,7 +733,12 @@ func (bot *CQBot) ConvertContentMessage(content []global.MSG, sourceType message
 			case *message.GroupImageElement:
 				img.Flash = flash
 				img.EffectID = id
-				img.ImageBizType = message.ImageBizType(data["subType"].(uint32))
+				switch data["subType"].(type) {
+				case int64:
+					img.ImageBizType = message.ImageBizType(data["subType"].(int64))
+				default:
+					img.ImageBizType = message.ImageBizType(data["subType"].(uint32))
+				}
 			case *message.FriendImageElement:
 				img.Flash = flash
 			}


### PR DESCRIPTION
NumberLong对应的类型是int64，断言为uint32触发panic
在此文件内其它有类型断言的地方也可能有类似的问题