### PR TITLE
可开关闭频道图片自动保存功能

### DIFF
--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -1151,9 +1151,14 @@ func (bot *CQBot) makeImageOrVideoElem(d map[string]string, video bool, sourceTy
 	}
 	// 目前频道内上传的图片均无法被查询到, 需要单独处理
 	if sourceType == message.SourceGuildChannel {
-		cacheFile := path.Join(global.ImagePath, "guild-images", f)
-		if global.PathExists(cacheFile) {
-			return &LocalImageElement{File: cacheFile}, nil
+		// 部分人不需要保存頻道圖片，判斷配置文件是否打開頻道下載完整圖片，是保持，否不保存
+		if base.ChannelImageCache {
+			cacheFile := path.Join(global.ImagePath, "guild-images", f)
+			if global.PathExists(cacheFile) {
+				return &LocalImageElement{File: cacheFile}, nil
+			}
+		} else {
+			return nil, nil
 		}
 	}
 	if strings.HasSuffix(f, ".image") {

--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -1151,14 +1151,9 @@ func (bot *CQBot) makeImageOrVideoElem(d map[string]string, video bool, sourceTy
 	}
 	// 目前频道内上传的图片均无法被查询到, 需要单独处理
 	if sourceType == message.SourceGuildChannel {
-		// 部分人不需要保存頻道圖片，判斷配置文件是否打開頻道下載完整圖片，是保持，否不保存
-		if base.ChannelImageCache {
-			cacheFile := path.Join(global.ImagePath, "guild-images", f)
-			if global.PathExists(cacheFile) {
-				return &LocalImageElement{File: cacheFile}, nil
-			}
-		} else {
-			return nil, nil
+		cacheFile := path.Join(global.ImagePath, "guild-images", f)
+		if global.PathExists(cacheFile) {
+			return &LocalImageElement{File: cacheFile}, nil
 		}
 	}
 	if strings.HasSuffix(f, ".image") {

--- a/coolq/event.go
+++ b/coolq/event.go
@@ -657,19 +657,22 @@ func (bot *CQBot) checkMedia(e []message.IMessageElement, sourceID int64) {
 			cache.Image.Insert(i.Md5, data)
 
 		case *message.GuildImageElement:
-			data := binary.NewWriterF(func(w *binary.Writer) {
-				w.Write(i.Md5)
-				w.WriteUInt32(uint32(i.Size))
-				w.WriteString(i.DownloadIndex)
-				w.WriteString(i.Url)
-			})
-			filename := hex.EncodeToString(i.Md5) + ".image"
-			cache.Image.Insert(i.Md5, data)
-			if i.Url != "" && !global.PathExists(path.Join(global.ImagePath, "guild-images", filename)) {
-				if err := global.DownloadFile(i.Url, path.Join(global.ImagePath, "guild-images", filename), -1, nil); err != nil {
-					log.Warnf("下载频道图片时出现错误: %v", err)
+			if base.ChannelImageCache {
+				data := binary.NewWriterF(func(w *binary.Writer) {
+					w.Write(i.Md5)
+					w.WriteUInt32(uint32(i.Size))
+					w.WriteString(i.DownloadIndex)
+					w.WriteString(i.Url)
+				})
+				filename := hex.EncodeToString(i.Md5) + ".image"
+				cache.Image.Insert(i.Md5, data)
+				if i.Url != "" && !global.PathExists(path.Join(global.ImagePath, "guild-images", filename)) {
+					if err := global.DownloadFile(i.Url, path.Join(global.ImagePath, "guild-images", filename), -1, nil); err != nil {
+						log.Warnf("下载频道图片时出现错误: %v", err)
+					}
 				}
 			}
+
 		case *message.FriendImageElement:
 			data := binary.NewWriterF(func(w *binary.Writer) {
 				w.Write(i.Md5)

--- a/internal/base/flag.go
+++ b/internal/base/flag.go
@@ -41,6 +41,7 @@ var (
 	LogColorful         bool // 是否启用日志颜色
 	FastStart           bool // 是否为快速启动
 	AllowTempSession    bool // 是否允许发送临时会话信息
+	ChannelImageCache   bool // 是否完全下载频道图片
 
 	PostFormat        string                 // 上报格式 string or array
 	Proxy             string                 // 存储 proxy_rewrite,用于设置代理
@@ -83,6 +84,7 @@ func Init() {
 		IgnoreInvalidCQCode = conf.Message.IgnoreInvalidCQCode
 		SplitURL = conf.Message.FixURL
 		RemoveReplyAt = conf.Message.RemoveReplyAt
+		ChannelImageCache = conf.Message.ChannelImageCache
 		ExtraReplyData = conf.Message.ExtraReplyData
 		ForceFragmented = conf.Message.ForceFragment
 		SkipMimeScan = conf.Message.SkipMimeScan

--- a/modules/api/api.go
+++ b/modules/api/api.go
@@ -48,7 +48,7 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 		p1 := p.Get("parent_id").String()
 		p2 := p.Get("name").String()
 		return c.bot.CQGroupFileCreateFolder(p0, p1, p2)
-	case "create_guild_role":
+	case "create_guild_role": //创建频道角色
 		p0 := p.Get("guild_id").Uint()
 		p1 := p.Get("name").String()
 		p2 := uint32(p.Get("color").Uint())
@@ -70,14 +70,14 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 		p0 := p.Get("group_id").Int()
 		p1 := p.Get("folder_id").String()
 		return c.bot.CQGroupFileDeleteFolder(p0, p1)
-	case "delete_guild_role":
+	case "delete_guild_role": // 删除频道角色
 		p0 := p.Get("guild_id").Uint()
 		p1 := p.Get("role_id").Uint()
 		return c.bot.CQDeleteGuildRole(p0, p1)
 	case "delete_msg":
 		p0 := int32(p.Get("message_id").Int())
 		return c.bot.CQDeleteMessage(p0)
-	case "delete_unidirectional_friend":
+	case "delete_unidirectional_friend": //删除单项好友
 		p0 := p.Get("user_id").Int()
 		return c.bot.CQDeleteUnidirectionalFriend(p0)
 	case "download_file":
@@ -154,11 +154,11 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 	case "get_guild_meta_by_guest":
 		p0 := p.Get("guild_id").Uint()
 		return c.bot.CQGetGuildMetaByGuest(p0)
-	case "get_guild_msg":
+	case "get_guild_msg": //获取频道信息
 		p0 := p.Get("message_id").String()
 		p1 := p.Get("no_cache").Bool()
 		return c.bot.CQGetGuildMessage(p0, p1)
-	case "get_guild_roles":
+	case "get_guild_roles": //获取频道角色列表,角色，不是成员，关键是role_name和role_id
 		p0 := p.Get("guild_id").Uint()
 		return c.bot.CQGetGuildRoles(p0)
 	case "get_guild_service_profile":
@@ -195,7 +195,7 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 	case "reload_event_filter":
 		p0 := p.Get("file").String()
 		return c.bot.CQReloadEventFilter(p0)
-	case "send_forward_msg":
+	case "send_forward_msg": //发送合并转发消息私聊群，到，自定义转发消息，类型private，可能无用
 		p0 := p.Get("group_id").Int()
 		p1 := p.Get("user_id").Int()
 		p2 := p.Get("messages")
@@ -226,7 +226,7 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 		p3 := p.Get("message_type").String()
 		p4 := p.Get("auto_escape").Bool()
 		return c.bot.CQSendMessage(p0, p1, p2, p3, p4)
-	case "send_private_forward_msg":
+	case "send_private_forward_msg": //发送合并转发消息私聊
 		p0 := p.Get("user_id").Int()
 		p1 := p.Get("messages")
 		return c.bot.CQSendPrivateForwardMessage(p0, p1)
@@ -311,7 +311,7 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 			p1 = pt.Bool()
 		}
 		return c.bot.CQSetGroupWholeBan(p0, p1)
-	case "set_guild_member_role":
+	case "set_guild_member_role": //设置用户在频道中的角色
 		p0 := p.Get("guild_id").Uint()
 		p1 := p.Get("set").Bool()
 		p2 := p.Get("role_id").Uint()
@@ -324,7 +324,7 @@ func (c *Caller) call(action string, p Getter) global.MSG {
 		p3 := p.Get("college")
 		p4 := p.Get("personal_note")
 		return c.bot.CQSetQQProfile(p0, p1, p2, p3, p4)
-	case "update_guild_role":
+	case "update_guild_role": //修改频道角色
 		p0 := p.Get("guild_id").Uint()
 		p1 := p.Get("role_id").Uint()
 		p2 := p.Get("name").String()

--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 		RemoveReplyAt       bool   `yaml:"remove-reply-at"`
 		ExtraReplyData      bool   `yaml:"extra-reply-data"`
 		SkipMimeScan        bool   `yaml:"skip-mime-scan"`
+		ChannelImageCache   bool   `yaml:"channel-image-cache"`
 	} `yaml:"message"`
 
 	Output struct {

--- a/modules/config/default_config.yml
+++ b/modules/config/default_config.yml
@@ -43,6 +43,8 @@ message:
   extra-reply-data: false
   # 跳过 Mime 扫描, 忽略错误数据
   skip-mime-scan: false
+  # 是否完全下载频道图片
+  channel-image-cache: true
 
 output:
   # 日志等级 trace,debug,info,warn,error


### PR DESCRIPTION
issues 2022年8月12日:无法关闭频道图片自动保存功能 #1628
有人提交这个需求，现做出这个需求
在message.channel-image-cache终结点里，填写false关闭频道保存图片，true开启，默认开启。关闭可提高服务器资源利用率，带宽.
实测关闭后成功不下载频道完整图片(仅限频道)
个人觉得这个功能可以，因为频道太多，图片也太多了。一天图片就有几百兆