### PR TITLE
常量httpDefault生成的格式错误修复

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -80,22 +80,22 @@ type httpCtx struct {
 
 const httpDefault = `
   - http: # HTTP 通信设置
-      address: 0.0.0.0:5700 # HTTP监听地址
-      timeout: 5      # 反向 HTTP 超时时间, 单位秒，<5 时将被忽略
-      long-polling:   # 长轮询拓展
-        enabled: false       # 是否开启
-        max-queue-size: 2000 # 消息队列大小，0 表示不限制队列大小，谨慎使用
-      middlewares:
-        <<: *default # 引用默认中间件
-      post:           # 反向HTTP POST地址列表
-      #- url: ''                # 地址
-      #  secret: ''             # 密钥
-      #  max-retries: 3         # 最大重试，0 时禁用
-      #  retries-interval: 1500 # 重试时间，单位毫秒，0 时立即
-      #- url: http://127.0.0.1:5701/ # 地址
-      #  secret: ''                  # 密钥
-      #  max-retries: 10             # 最大重试，0 时禁用
-      #  retries-interval: 1000      # 重试时间，单位毫秒，0 时立即
+	address: 0.0.0.0:5700 # HTTP监听地址
+	timeout: 5      # 反向 HTTP 超时时间, 单位秒，<5 时将被忽略
+	long-polling:   # 长轮询拓展
+	enabled: false       # 是否开启
+	max-queue-size: 2000 # 消息队列大小，0 表示不限制队列大小，谨慎使用
+	middlewares:
+	<<: *default # 引用默认中间件
+	post:           # 反向HTTP POST地址列表
+	#- url: ''                # 地址
+	#  secret: ''             # 密钥
+	#  max-retries: 3         # 最大重试，0 时禁用
+	#  retries-interval: 1500 # 重试时间，单位毫秒，0 时立即
+	#- url: http://127.0.0.1:5701/ # 地址
+	#  secret: ''                  # 密钥
+	#  max-retries: 10             # 最大重试，0 时禁用
+	#  retries-interval: 1000      # 重试时间，单位毫秒，0 时立即
 `
 
 func init() {

--- a/server/http.go
+++ b/server/http.go
@@ -80,22 +80,22 @@ type httpCtx struct {
 
 const httpDefault = `
   - http: # HTTP 通信设置
-	address: 0.0.0.0:5700 # HTTP监听地址
-	timeout: 5      # 反向 HTTP 超时时间, 单位秒，<5 时将被忽略
-	long-polling:   # 长轮询拓展
-	enabled: false       # 是否开启
-	max-queue-size: 2000 # 消息队列大小，0 表示不限制队列大小，谨慎使用
-	middlewares:
-	<<: *default # 引用默认中间件
-	post:           # 反向HTTP POST地址列表
-	#- url: ''                # 地址
-	#  secret: ''             # 密钥
-	#  max-retries: 3         # 最大重试，0 时禁用
-	#  retries-interval: 1500 # 重试时间，单位毫秒，0 时立即
-	#- url: http://127.0.0.1:5701/ # 地址
-	#  secret: ''                  # 密钥
-	#  max-retries: 10             # 最大重试，0 时禁用
-	#  retries-interval: 1000      # 重试时间，单位毫秒，0 时立即
+    address: 0.0.0.0:5700 # HTTP监听地址
+    timeout: 5      # 反向 HTTP 超时时间, 单位秒，<5 时将被忽略
+    long-polling:   # 长轮询拓展
+      enabled: false       # 是否开启
+      max-queue-size: 2000 # 消息队列大小，0 表示不限制队列大小，谨慎使用
+    middlewares:
+      <<: *default # 引用默认中间件
+    post:           # 反向HTTP POST地址列表
+    #- url: ''                # 地址
+    #  secret: ''             # 密钥
+    #  max-retries: 3         # 最大重试，0 时禁用
+    #  retries-interval: 1500 # 重试时间，单位毫秒，0 时立即
+    #- url: http://127.0.0.1:5701/ # 地址
+    #  secret: ''                  # 密钥
+    #  max-retries: 10             # 最大重试，0 时禁用
+    #  retries-interval: 1000      # 重试时间，单位毫秒，0 时立即
 `
 
 func init() {


### PR DESCRIPTION
生成配置时选择0 http,  生成的配置文件中存在格式不对的问题

```
# 连接服务列表
servers:
  # 添加方式，同一连接方式可添加多个，具体配置说明请查看文档
  #- http: # http 通信
  #- ws:   # 正向 Websocket
  #- ws-reverse: # 反向 Websocket
  #- pprof: #性能分析服务器

  - http: # HTTP 通信设置
      address: 0.0.0.0:5700 # HTTP监听地址
      timeout: 5      # 反向 HTTP 超时时间, 单位秒，<5 时将被忽略
      long-polling:   # 长轮询拓展
        enabled: false       # 是否开启
        max-queue-size: 2000 # 消息队列大小，0 表示不限制队列大小，谨慎使用
      middlewares:
        <<: *default # 引用默认中间件
      post:           # 反向HTTP POST地址列表
      # - url: ''                # 地址
      #  secret: ''             # 密钥
      #  max-retries: 3         # 最大重试，0 时禁用
      #  retries-interval: 1500 # 重试时间，单位毫秒，0 时立即
      #- url: http://127.0.0.1:5701/ # 地址
      #  secret: ''                  # 密钥
      #  max-retries: 10             # 最大重试，0 时禁用
      #  retries-interval: 1000      # 重试时间，单位毫秒，0 时立即
```

运行结果如下

```
time="2022-09-10T17:49:55+08:00" level=fatal msg="配置文件不合法!yaml: line 96: did not find expected key"
```

### 原因

config.yml生成时- http下的子元素多了两列空格, 删掉两列空格可正常运行, 解决办法如下

```
# 连接服务列表
servers:
  # 添加方式，同一连接方式可添加多个，具体配置说明请查看文档
  #- http: # http 通信
  #- ws:   # 正向 Websocket
  #- ws-reverse: # 反向 Websocket
  #- pprof: #性能分析服务器

  - http: # HTTP 通信设置
    address: 0.0.0.0:5700 # HTTP监听地址
    timeout: 5      # 反向 HTTP 超时时间, 单位秒，<5 时将被忽略
    long-polling:   # 长轮询拓展
      enabled: false       # 是否开启
      max-queue-size: 2000 # 消息队列大小，0 表示不限制队列大小，谨慎使用
    middlewares:
      <<: *default # 引用默认中间件
    post:           # 反向HTTP POST地址列表
    # - url: ''                # 地址
    #  secret: ''             # 密钥
    #  max-retries: 3         # 最大重试，0 时禁用
    #  retries-interval: 1500 # 重试时间，单位毫秒，0 时立即
    #- url: http://127.0.0.1:5701/ # 地址
    #  secret: ''                  # 密钥
    #  max-retries: 10             # 最大重试，0 时禁用
    #  retries-interval: 1000      # 重试时间，单位毫秒，0 时立即
```