### PR TITLE
将反向HTTP POST服务中请求的Method由GET修改为POST

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -356,7 +356,7 @@ func (c *HTTPClient) onBotPushEvent(e *coolq.Event) {
 	for i := uint64(0); i <= c.MaxRetries; i++ {
 		// see https://stackoverflow.com/questions/31337891/net-http-http-contentlength-222-with-body-length-0
 		// we should create a new request for every single post trial
-		req, err = http.NewRequest(http.MethodGet, c.addr, bytes.NewReader(e.JSONBytes()))
+		req, err = http.NewRequest(http.MethodPost, c.addr, bytes.NewReader(e.JSONBytes()))
 		if err != nil {
 			log.Warnf("上报 Event 数据到 %v 时创建请求失败: %v", c.addr, err)
 			return


### PR DESCRIPTION
我看到在`master`分支中，相关代码所实现的反向HTTP POST服务中请求的Method为`POST`，但在`dev`分支中它被修改为`GET`；
这项改动在[all: fix golangci-lint](https://github.com/Mrs4s/go-cqhttp/commit/656dc6b1035c8b6d40c4cc8c2565a15d7785ca50#diff-9dc8ed5b73297cf3c3d1d32cb36520c8f982a0194fad1e7b3fc521c5799e2023)中被引入，我认为它应当被修正为`POST`；