### PR TITLE
fix: FindFile http return nil without cache

### DIFF
--- a/global/fs.go
+++ b/global/fs.go
@@ -88,6 +88,7 @@ func FindFile(file, cache, p string) (data []byte, err error) {
 		if err != nil {
 			return nil, err
 		}
+		return os.ReadFile(cacheFile)
 	case strings.HasPrefix(file, "base64"):
 		data, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(file, "base64://"))
 		if err != nil {


### PR DESCRIPTION
修复 FindFile 方法在 http 协议且无缓存的情况下返回空数据
fix #1831 