### PR TITLE
fix: slider captcha default use qrcode

### DIFF
--- a/cmd/gocq/login.go
+++ b/cmd/gocq/login.go
@@ -159,18 +159,18 @@ func loginResponseProcessor(res *client.LoginResponse) error {
 			log.Warnf("2. 使用手机QQ扫码验证 (需要手Q和gocq在同一网络下).")
 			log.Warn("请输入(1 - 2)：")
 			text = readIfTTY("1")
-			if strings.Contains(text, "1") {
-				ticket := getTicket(res.VerifyUrl)
-				if ticket == "" {
-					os.Exit(0)
-				}
-				res, err = cli.SubmitTicket(ticket)
-				continue
+			if strings.Contains(text, "2") {
+				cli.Disconnect()
+				cli.Release()
+				cli = client.NewClientEmpty()
+				return qrcodeLogin()
 			}
-			cli.Disconnect()
-			cli.Release()
-			cli = client.NewClientEmpty()
-			return qrcodeLogin()
+			ticket := getTicket(res.VerifyUrl)
+			if ticket == "" {
+				os.Exit(0)
+			}
+			res, err = cli.SubmitTicket(ticket)
+			continue
 		case client.NeedCaptcha:
 			log.Warnf("登录需要验证码.")
 			_ = os.WriteFile("captcha.jpg", res.CaptchaImage, 0o644)


### PR DESCRIPTION
## 原先行为

当登录需要滑条验证码时，如果用户输入其他值（如 `3` 或者根本没有输入）就会使用 `2` 的行为。

按照正常逻辑：
![image](https://user-images.githubusercontent.com/64234553/214304883-3bab206c-ab16-4e70-91dc-954ecf93a5a4.png)
应该会认为1是默认值，所以使用 `2` 的行为有点反直觉。

## 目前行为

修改了判断顺序，使得如果输入值为空或者其他值默认使用 `1` 的行为。

## 其他信息

https://github.com/Mrs4s/go-cqhttp/blob/64653a6815de12f8450b292cb6a265a72b1bec6b/cmd/gocq/login.go#L161-L163

我注意到判断选用哪个行为使用的函数是 `strings.Contains()` ，如果用户输入为 `12` 会导致一些难以预期的结果，但我不确定我应该怎么做，我认为这个问题可以讨论一下。我暂时先不擅自更改逻辑了。