### PR TITLE
修复取出消息时LocalImageElement缺失问题

### DIFF
--- a/coolq/cqcode.go
+++ b/coolq/cqcode.go
@@ -282,6 +282,18 @@ func toElements(e []message.IMessageElement, source message.Source) (r []cqcode.
 					{K: "type", V: "sticker"},
 				},
 			}
+		case *LocalImageElement:
+			data := pairs{
+				{K: "file", V: o.File},
+				{K: "url", V: o.URL},
+			}
+			if o.Flash {
+				data = append(data, pair{K: "type", V: "flash"})
+			}
+			m = cqcode.Element{
+				Type: "image",
+				Data: data,
+			}
 		default:
 			continue
 		}


### PR DESCRIPTION
如果通过go-cqhttp发送图片，再通过message_id 从数据库取出时，返回的message为空。
修复这个bug。