### PR TITLE
fix: BINARY_NAME wrong in ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           if [ $GOOS = "windows" ]; then export BINARY_SUFFIX="$BINARY_SUFFIX.exe"; fi
           if $IS_PR ; then echo $PR_PROMPT; fi
-          export BINARY_NAME="$BINARY_PREFIX$GOOS_$GOARCH$BINARY_SUFFIX"
+          export BINARY_NAME="$BINARY_PREFIX"$GOOS"_$GOARCH$BINARY_SUFFIX"
           export CGO_ENABLED=0
           export LD_FLAGS="-w -s -X github.com/Mrs4s/go-cqhttp/internal/base.Version=${COMMIT_ID::7}"
           go build -o "output/$BINARY_NAME" -trimpath -ldflags "$LD_FLAGS" .


### PR DESCRIPTION
修复了 工件中未按预期 拼接二进制文件名 的问题。
原： ![image](https://user-images.githubusercontent.com/39934721/217624867-ebbe3b06-b95e-4fca-b1ec-e20d377984c4.png)
