### PR TITLE
feat: 禁用快速编辑&优化启动流程

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -43,7 +43,9 @@ var allowStatus = [...]client.UserOnlineStatus{
 
 // InitBase 解析参数并检测
 //
-//	如果在 windows 下双击打开了程序，程序将在此函数释出脚本后终止
+//	如果在 windows 下双击打开了程序，程序将在此函数释出脚本后终止；
+//	如果传入 -h 参数，程序将打印帮助后终止；
+//	如果传入 -d 参数，程序将在启动 daemon 后终止。
 func InitBase() {
 	base.Parse()
 	if !base.FastStart && terminal.RunningByDoubleClick() {

--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -41,8 +41,10 @@ var allowStatus = [...]client.UserOnlineStatus{
 	client.StatusGaming, client.StatusVacationing, client.StatusWatchingTV, client.StatusFitness,
 }
 
-// Main 启动主程序
-func Main() {
+// InitBase 解析参数并检测
+//
+//	如果在 windows 下双击打开了程序，程序将在此函数释出脚本后终止
+func InitBase() {
 	base.Parse()
 	if !base.FastStart && terminal.RunningByDoubleClick() {
 		err := terminal.NoMoreDoubleClick()
@@ -50,7 +52,7 @@ func Main() {
 			log.Errorf("遇到错误: %v", err)
 			time.Sleep(time.Second * 5)
 		}
-		return
+		os.Exit(0)
 	}
 	switch {
 	case base.LittleH:
@@ -65,7 +67,10 @@ func Main() {
 		}
 	}
 	base.Init()
+}
 
+// Main 启动主程序，必须在 InitBase 之后执行
+func Main() {
 	rotateOptions := []rotatelogs.Option{
 		rotatelogs.WithRotationTime(time.Hour * 24),
 	}

--- a/global/terminal/doc.go
+++ b/global/terminal/doc.go
@@ -1,2 +1,2 @@
-// Package terminal 包含用于检测在windows下是否通过双击运行go-cqhttp的函数
+// Package terminal 包含用于检测在windows下是否通过双击运行go-cqhttp, 禁用快速编辑, 启用VT100的函数
 package terminal

--- a/global/terminal/double_click.go
+++ b/global/terminal/double_click.go
@@ -2,7 +2,7 @@
 
 package terminal
 
-// RunningByDoubleClick 检查是否通过双击直接运行,非Windows系统永远返回false
+// RunningByDoubleClick 检查是否通过双击直接运行，非Windows系统永远返回false
 func RunningByDoubleClick() bool {
 	return false
 }

--- a/global/terminal/quick_edit.go
+++ b/global/terminal/quick_edit.go
@@ -1,0 +1,6 @@
+package terminal
+
+// DisableQuickEdit 禁用快速编辑，非Windows系统永远返回nil
+func DisableQuickEdit() error {
+	return nil
+}

--- a/global/terminal/quick_edit.go
+++ b/global/terminal/quick_edit.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package terminal
 
 // DisableQuickEdit 禁用快速编辑，非Windows系统永远返回nil

--- a/global/terminal/quick_edit.go
+++ b/global/terminal/quick_edit.go
@@ -2,6 +2,11 @@
 
 package terminal
 
+// RestoreInputMode 还原输入模式，非Windows系统永远返回nil
+func RestoreInputMode() error {
+	return nil
+}
+
 // DisableQuickEdit 禁用快速编辑，非Windows系统永远返回nil
 func DisableQuickEdit() error {
 	return nil

--- a/global/terminal/quick_edit_windows.go
+++ b/global/terminal/quick_edit_windows.go
@@ -1,6 +1,10 @@
 package terminal
 
-import "golang.org/x/sys/windows"
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
 
 // DisableQuickEdit 禁用快速编辑
 func DisableQuickEdit() error {

--- a/global/terminal/quick_edit_windows.go
+++ b/global/terminal/quick_edit_windows.go
@@ -19,5 +19,8 @@ func DisableQuickEdit() error {
 	mode &^= windows.ENABLE_QUICK_EDIT_MODE // 禁用快速编辑模式
 	mode |= windows.ENABLE_EXTENDED_FLAGS   // 启用扩展标志
 
+	mode &^= windows.ENABLE_MOUSE_INPUT    // 禁用鼠标输入
+	mode |= windows.ENABLE_PROCESSED_INPUT // 启用控制输入
+
 	return windows.SetConsoleMode(stdin, mode)
 }

--- a/global/terminal/quick_edit_windows.go
+++ b/global/terminal/quick_edit_windows.go
@@ -1,0 +1,19 @@
+package terminal
+
+import "golang.org/x/sys/windows"
+
+// DisableQuickEdit 禁用快速编辑
+func DisableQuickEdit() error {
+	stdin := windows.Handle(os.Stdin.Fd())
+
+	var mode uint32
+	err := windows.GetConsoleMode(stdin, &mode)
+	if err != nil {
+		return err
+	}
+
+	mode &^= windows.ENABLE_QUICK_EDIT_MODE // 禁用快速编辑模式
+	mode |= windows.ENABLE_EXTENDED_FLAGS   // 启用扩展标志
+
+	return windows.SetConsoleMode(stdin, mode)
+}

--- a/global/terminal/quick_edit_windows.go
+++ b/global/terminal/quick_edit_windows.go
@@ -22,5 +22,11 @@ func DisableQuickEdit() error {
 	mode &^= windows.ENABLE_MOUSE_INPUT    // 禁用鼠标输入
 	mode |= windows.ENABLE_PROCESSED_INPUT // 启用控制输入
 
+	mode &^= windows.ENABLE_INSERT_MODE                           // 禁用插入模式
+	mode |= windows.ENABLE_ECHO_INPUT | windows.ENABLE_LINE_INPUT // 启用输入回显&逐行输入
+
+	mode &^= windows.ENABLE_WINDOW_INPUT           // 禁用窗口输入
+	mode &^= windows.ENABLE_VIRTUAL_TERMINAL_INPUT // 禁用虚拟终端输入
+
 	return windows.SetConsoleMode(stdin, mode)
 }

--- a/global/terminal/quick_edit_windows.go
+++ b/global/terminal/quick_edit_windows.go
@@ -6,6 +6,17 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var inputmode uint32
+
+// RestoreInputMode 还原输入模式
+func RestoreInputMode() error {
+	if inputmode == 0 {
+		return nil
+	}
+	stdin := windows.Handle(os.Stdin.Fd())
+	return windows.SetConsoleMode(stdin, mode)
+}
+
 // DisableQuickEdit 禁用快速编辑
 func DisableQuickEdit() error {
 	stdin := windows.Handle(os.Stdin.Fd())
@@ -15,6 +26,7 @@ func DisableQuickEdit() error {
 	if err != nil {
 		return err
 	}
+	inputmode = mode
 
 	mode &^= windows.ENABLE_QUICK_EDIT_MODE // 禁用快速编辑模式
 	mode |= windows.ENABLE_EXTENDED_FLAGS   // 启用扩展标志

--- a/global/terminal/quick_edit_windows.go
+++ b/global/terminal/quick_edit_windows.go
@@ -14,7 +14,7 @@ func RestoreInputMode() error {
 		return nil
 	}
 	stdin := windows.Handle(os.Stdin.Fd())
-	return windows.SetConsoleMode(stdin, mode)
+	return windows.SetConsoleMode(stdin, inputmode)
 }
 
 // DisableQuickEdit 禁用快速编辑

--- a/global/terminal/vt100.go
+++ b/global/terminal/vt100.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package terminal
 
 // EnableVT100 启用颜色、控制字符，非Windows系统永远返回nil

--- a/global/terminal/vt100.go
+++ b/global/terminal/vt100.go
@@ -1,0 +1,6 @@
+package terminal
+
+// EnableVT100 启用颜色、控制字符，非Windows系统永远返回nil
+func EnableVT100() error {
+	return nil
+}

--- a/global/terminal/vt100_windows.go
+++ b/global/terminal/vt100_windows.go
@@ -1,0 +1,19 @@
+package terminal
+
+import "golang.org/x/sys/windows"
+
+// EnableVT100 启用颜色、控制字符
+func EnableVT100() error {
+	stdout := windows.Handle(os.Stdout.Fd())
+
+	var mode uint32
+	err := windows.GetConsoleMode(stdout, &mode)
+	if err != nil {
+		return err
+	}
+
+	mode |= windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING // 启用虚拟终端处理
+	mode |= windows.ENABLE_PROCESSED_OUTPUT            // 启用处理后的输出
+
+	return windows.SetConsoleMode(stdout, mode)
+}

--- a/global/terminal/vt100_windows.go
+++ b/global/terminal/vt100_windows.go
@@ -1,6 +1,10 @@
 package terminal
 
-import "golang.org/x/sys/windows"
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
 
 // EnableVT100 启用颜色、控制字符
 func EnableVT100() error {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	gocq.InitBase()
-	terminal.DisableQuickEdit()
-	terminal.EnableVT100()
+	_ = terminal.DisableQuickEdit()
+	_ = terminal.EnableVT100()
 	gocq.Main()
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"github.com/Mrs4s/go-cqhttp/cmd/gocq"
+	"github.com/Mrs4s/go-cqhttp/global/terminal"
 
 	_ "github.com/Mrs4s/go-cqhttp/db/leveldb"   // leveldb 数据库支持
 	_ "github.com/Mrs4s/go-cqhttp/modules/silk" // silk编码模块
@@ -13,5 +14,8 @@ import (
 )
 
 func main() {
+	gocq.InitBase()
+	terminal.DisableQuickEdit()
+	terminal.EnableVT100()
 	gocq.Main()
 }

--- a/main.go
+++ b/main.go
@@ -18,4 +18,5 @@ func main() {
 	_ = terminal.DisableQuickEdit()
 	_ = terminal.EnableVT100()
 	gocq.Main()
+	_ = terminal.RestoreInputMode()
 }


### PR DESCRIPTION
- 在解析参数之后，设置log之前禁用快速编辑并启用VT100
- 分离 Main 最开头的一段为 InitBase，一是为了可以让调包用户自定义参数，二是为了在二者之间插入快速编辑的逻辑，且如果用户不希望禁用快速编辑，可以方便地将其注释