### PR TITLE
增加签名服务器请求超时时间

### DIFF
--- a/cmd/gocq/login.go
+++ b/cmd/gocq/login.go
@@ -265,15 +265,19 @@ func fetchCaptcha(id string) string {
 	return ""
 }
 
-func energy(uin uint64, id string, appVersion string, salt []byte) ([]byte, error) {
+func energy(uin uint64, id string, _ string, salt []byte) ([]byte, error) {
 	signServer := base.SignServer
 	if !strings.HasSuffix(signServer, "/") {
 		signServer += "/"
 	}
-	response, err := download.Request{
+	req := download.Request{
 		Method: http.MethodGet,
-		URL:    signServer + "custom_energy" + fmt.Sprintf("?data=%v&salt=%v", id, hex.EncodeToString(salt)),
-	}.Bytes()
+		URL:    signServer + "custom_energy" + fmt.Sprintf("?data=%v&salt=%v&uin=%v", id, hex.EncodeToString(salt), uin),
+	}
+	if base.IsBelow110 {
+		req.URL = signServer + "custom_energy" + fmt.Sprintf("?data=%v&salt=%v", id, hex.EncodeToString(salt))
+	}
+	response, err := req.Bytes()
 	if err != nil {
 		log.Warnf("获取T544 sign时出现错误: %v server: %v", err, signServer)
 		return nil, err
@@ -309,4 +313,30 @@ func sign(seq uint64, uin string, cmd string, qua string, buff []byte) (sign []b
 	extra, _ = hex.DecodeString(gjson.GetBytes(response, "data.extra").String())
 	token, _ = hex.DecodeString(gjson.GetBytes(response, "data.token").String())
 	return sign, extra, token, nil
+}
+
+func register(uin int64, androidID, guid []byte, qimei36, key string) {
+	if base.IsBelow110 {
+		log.Warn("签名服务器版本低于1.1.0, 跳过实例注册")
+		return
+	}
+	signServer := base.SignServer
+	if !strings.HasSuffix(signServer, "/") {
+		signServer += "/"
+	}
+	resp, err := download.Request{
+		Method: http.MethodGet,
+		URL: signServer + "register" + fmt.Sprintf("?uin=%v&android_id=%v&guid=%v&qimei36=%v&key=%s",
+			uin, hex.EncodeToString(androidID), hex.EncodeToString(guid), qimei36, key),
+	}.Bytes()
+	if err != nil {
+		log.Warnf("注册QQ实例时出现错误: %v server: %v", err, signServer)
+		return
+	}
+	msg := gjson.GetBytes(resp, "msg")
+	if gjson.GetBytes(resp, "code").Int() != 0 {
+		log.Warnf("注册QQ实例时出现错误: %v server: %v", msg, signServer)
+		return
+	}
+	log.Infof("注册QQ实例 %v 成功: %v", uin, msg)
 }

--- a/cmd/gocq/login.go
+++ b/cmd/gocq/login.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/Mrs4s/MiraiGo/client"
 	"github.com/Mrs4s/MiraiGo/utils"
-	"github.com/Mrs4s/go-cqhttp/internal/base"
 	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"gopkg.ilharper.com/x/isatty"
+
+	"github.com/Mrs4s/go-cqhttp/internal/base"
 
 	"github.com/Mrs4s/go-cqhttp/global"
 	"github.com/Mrs4s/go-cqhttp/internal/download"

--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -166,6 +166,7 @@ func LoginInteract() {
 
 	if base.SignServer != "-" && base.SignServer != "" {
 		log.Infof("使用服务器 %s 进行数据包签名", base.SignServer)
+		register(base.Account.Uin, device.AndroidId, device.Guid, device.QImei36, base.Key)
 		wrapper.DandelionEnergy = energy
 		wrapper.FekitGetSign = sign
 	} else {

--- a/internal/base/flag.go
+++ b/internal/base/flag.go
@@ -39,6 +39,8 @@ var (
 	AllowTempSession    bool   // 是否允许发送临时会话信息
 	UpdateProtocol      bool   // 是否更新协议
 	SignServer          string // 使用特定的服务器进行签名
+	Key                 string // 签名服务器密钥
+	IsBelow110          bool   // 签名服务器版本是否低于1.1.0及以下
 	HTTPTimeout         int
 
 	PostFormat        string                 // 上报格式 string or array
@@ -89,6 +91,8 @@ func Init() {
 		UseSSOAddress = conf.Account.UseSSOAddress
 		AllowTempSession = conf.Account.AllowTempSession
 		SignServer = conf.Account.SignServer
+		Key = conf.Account.Key
+		IsBelow110 = conf.Account.IsBelow110
 		HTTPTimeout = conf.Message.HTTPTimeout
 	}
 	{ // others

--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -36,6 +36,8 @@ type Account struct {
 	UseSSOAddress    bool       `yaml:"use-sso-address"`
 	AllowTempSession bool       `yaml:"allow-temp-session"`
 	SignServer       string     `yaml:"sign-server"`
+	Key              string     `yaml:"key"`
+	IsBelow110       bool       `yaml:"is-below-110"`
 }
 
 // Config 总配置文件

--- a/modules/config/default_config.yml
+++ b/modules/config/default_config.yml
@@ -24,6 +24,11 @@ account: # 账号相关
   # sign-server: 'https://signserver.example.com' # 线上签名服务器
   # 服务器可使用docker在本地搭建或者使用他人开放的服务
   sign-server: '-'
+  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
+  is-below-110: false
+  # 签名服务器所需要的apikey, 如果签名服务器的版本在1.1.0及以下则此项无效
+  # 本地部署的默认为114514
+  key: '114514'
 
 heartbeat:
   # 心跳频率, 单位秒


### PR DESCRIPTION
比如我的香橙派，因为性能很差，所以运行签名服务器的时候需要把超时改成50秒才能成功。（而M1瞬间就好了，我搞了半天不知道为什么同一个Dockerfile会跑出不同的结果 :sob: )

也许这个改成一个配置文件的项目会更好一点？不过改那么多对我来说比较难（）（）