### PR TITLE
增加签名服务器请求超时时间

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -33,7 +33,7 @@ var client = &http.Client{
 		TLSNextProto:        map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 		MaxIdleConnsPerHost: 999,
 	},
-	Timeout: time.Second * 5,
+	Timeout: time.Second * 50,
 }
 
 var clienth2 = &http.Client{

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -33,7 +33,7 @@ var client = &http.Client{
 		TLSNextProto:        map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 		MaxIdleConnsPerHost: 999,
 	},
-	Timeout: time.Second * 50,
+	Timeout: time.Minute,
 }
 
 var clienth2 = &http.Client{


### PR DESCRIPTION
比如我的香橙派，因为性能很差，所以运行签名服务器的时候需要把超时改成50秒才能成功。（而M1瞬间就好了，我搞了半天不知道为什么同一个Dockerfile同一个架构会跑出不同的结果 :sob:  )

也许这个改成一个配置文件的项目会更好一点？不过改那么多对我来说比较难（）（）
