### PR TITLE
feat: After the sign server is up and running, proceed with registering the instance and support automatic registration

### DIFF
--- a/cmd/gocq/login.go
+++ b/cmd/gocq/login.go
@@ -275,7 +275,8 @@ func energy(uin uint64, id string, _ string, salt []byte) ([]byte, error) {
 	}
 	req := download.Request{
 		Method: http.MethodGet,
-		URL:    signServer + "custom_energy" + fmt.Sprintf("?data=%v&salt=%v&uin=%v", id, hex.EncodeToString(salt), uin),
+		URL: signServer + "custom_energy" + fmt.Sprintf("?data=%v&salt=%v&uin=%v&android_id=%v&guid=%v",
+			id, hex.EncodeToString(salt), uin, hex.EncodeToString(device.AndroidId), hex.EncodeToString(device.Guid)),
 	}
 	if base.IsBelow110 {
 		req.URL = signServer + "custom_energy" + fmt.Sprintf("?data=%v&salt=%v", id, hex.EncodeToString(salt))
@@ -304,7 +305,7 @@ func sign(seq uint64, uin string, cmd string, qua string, buff []byte) (sign []b
 	}
 	response, err := download.Request{
 		Method: http.MethodPost,
-		URL:    signServer + "sign",
+		URL:    signServer + "sign"+fmt.Sprintf("?),
 		Header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 		Body:   bytes.NewReader([]byte(fmt.Sprintf("uin=%v&qua=%s&cmd=%s&seq=%v&buffer=%v", uin, qua, cmd, seq, hex.EncodeToString(buff)))),
 	}.Bytes()

--- a/cmd/gocq/login.go
+++ b/cmd/gocq/login.go
@@ -17,13 +17,12 @@ import (
 
 	"github.com/Mrs4s/MiraiGo/client"
 	"github.com/Mrs4s/MiraiGo/utils"
+	"github.com/Mrs4s/go-cqhttp/internal/base"
 	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"gopkg.ilharper.com/x/isatty"
-
-	"github.com/Mrs4s/go-cqhttp/internal/base"
 
 	"github.com/Mrs4s/go-cqhttp/global"
 	"github.com/Mrs4s/go-cqhttp/internal/download"
@@ -306,7 +305,7 @@ func sign(seq uint64, uin string, cmd string, qua string, buff []byte) (sign []b
 	}
 	response, err := download.Request{
 		Method: http.MethodPost,
-		URL:    signServer + "sign"+fmt.Sprintf("?),
+		URL:    signServer + "sign" + fmt.Sprintf("?android_id=%v&guid=%v", hex.EncodeToString(device.AndroidId), hex.EncodeToString(device.Guid)),
 		Header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 		Body:   bytes.NewReader([]byte(fmt.Sprintf("uin=%v&qua=%s&cmd=%s&seq=%v&buffer=%v", uin, qua, cmd, seq, hex.EncodeToString(buff)))),
 	}.Bytes()

--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -166,6 +166,8 @@ func LoginInteract() {
 
 	if base.SignServer != "-" && base.SignServer != "" {
 		log.Infof("使用服务器 %s 进行数据包签名", base.SignServer)
+		// 等待签名服务器直到连接成功
+		waitForConnection()
 		register(base.Account.Uin, device.AndroidId, device.Guid, device.QImei36, base.Key)
 		wrapper.DandelionEnergy = energy
 		wrapper.FekitGetSign = sign


### PR DESCRIPTION
#2303 
The previous versions didn't wait for the sign server to start before performing instance registration. This issue has been fixed now.

It also supports the automatic registration feature of the current version of the sign server, thereby avoiding the situation where the program has to be restarted to re-register instances after the sign server crashes.

add functions in cmd/gocq/login.go:
 The functions listenPort, dailPort, and waitForConnection use net.Dial to check if the sign server is running every five seconds. They will remain blocked until the sign server is started. 
