### PR TITLE
Update download.go

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -33,7 +33,7 @@ var client = &http.Client{
 		TLSNextProto:        map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 		MaxIdleConnsPerHost: 999,
 	},
-	Timeout: time.Second * 5,
+	Timeout: time.Second * 15,
 }
 
 var clienth2 = &http.Client{
@@ -47,7 +47,7 @@ var clienth2 = &http.Client{
 		ForceAttemptHTTP2:   true,
 		MaxIdleConnsPerHost: 999,
 	},
-	Timeout: time.Second * 5,
+	Timeout: time.Second * 15,
 }
 
 // ErrOverSize 响应主体过大时返回此错误


### PR DESCRIPTION
解决注册qq实例超时问题
[WARNING]: 注册QQ实例时出现错误: Get "http://127.0.0.1:18080/register?uin=000000000&android_id=66396563643366343934623432640000&guid=6a3911229bdc3ea14219571b30000adc&qimei36=aafeb91386e5e30ee75581be10001f50000c&key=114514": context deadline exceeded (Client.Timeout exceeded while awaiting headers) server: http://127.0.0.1:18080