### PR TITLE
fix: group not found report (#2312)

### DIFF
--- a/coolq/api.go
+++ b/coolq/api.go
@@ -1149,7 +1149,9 @@ func (bot *CQBot) CQDelGroupMemo(groupID int64, fid string) global.MSG {
 // @rename(msg->message, block->reject_add_request)
 func (bot *CQBot) CQSetGroupKick(groupID int64, userID int64, msg string, block bool) global.MSG {
 	if g := bot.Client.FindGroup(groupID); g != nil {
-		if m := g.FindMember(userID); m != nil {
+		if m := g.FindMember(userID); m == nil {
+			return Failed(100, "MEMBER_IS_NOT_IN_GROUP", "人员不存在")
+		} else {
 			err := m.Kick(msg, block)
 			if err != nil {
 				return Failed(100, "NOT_MANAGEABLE", "机器人权限不足")


### PR DESCRIPTION
解决以下问题：
当群组踢人时，该人不在群内，返回“群聊不存在”的BUG

https://github.com/Mrs4s/go-cqhttp/issues/1774#issue-1459854639