### PR TITLE
Fix: SignServer TCP ping for custom port

### DIFF
--- a/cmd/gocq/login.go
+++ b/cmd/gocq/login.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image"
 	"image/png"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -541,7 +542,18 @@ func signWaitServer() bool {
 			log.Warnf("连接到签名服务器出现错误: %v", err)
 			continue
 		}
-		r := utils.RunTCPPingLoop(u.Host, 4)
+		host := u.Hostname()
+		port := u.Port()
+		if port == "" {
+			switch u.Scheme {
+			case "https":
+				port = "443"
+			case "http":
+				port = "80"
+			}
+		}
+		hostPort := net.JoinHostPort(host, port)
+		r := utils.RunTCPPingLoop(hostPort, 4)
 		if r.PacketsLoss > 0 {
 			log.Warnf("连接到签名服务器出现错误: 丢包%d/%d 时延%dms", r.PacketsLoss, r.PacketsSent, r.AvgTimeMill)
 			continue


### PR DESCRIPTION
解决了对于使用了强制 https 的 SignServer 在进行 TCP ping 时 错误的只截取了 host ，导致判定使用 80 端口而始终 ping 不通
的问题

TCP ping
http://xxx.com √
https://xxx.com:443 √
https://xxx.com ×

```bash
[2023-08-07 08:48:11] [INFO]: 使用服务器 https://xxx.com/ 进
行数据包签名
[2023-08-07 08:48:17] [WARNING]: 连接到签名服务器出现错误: 丢包4/4 时延9999ms
[2023-08-07 08:48:22] [WARNING]: 连接到签名服务器出现错误: 丢包4/4 时延9999ms
[2023-08-07 08:48:27] [WARNING]: 连接到签名服务器出现错误: 丢包4/4 时延9999ms
[2023-08-07 08:48:32] [WARNING]: 连接到签名服务器出现错误: 丢包4/4 时延9999ms
[2023-08-07 08:48:36] [FATAL]: 连接签名服务器失败
```

现在，它应该能正确的通过以上 TCP ping 的逻辑

同时，也确保了对于非 80/443 端口的 SignServer 服务器的 TCP ping 支持
```bash
[2023-08-07 08:58:53] [INFO]: 使用服务器 https://xxx.com/ 进
行数据包签名
[2023-08-07 08:59:00] [INFO]: 连接至签名服务器: https://xxx.com/
[2023-08-07 08:59:10] [INFO]: 注册QQ实例 10001成功: The QQ has already loaded an instance, so this time it is deleting the existing instance and creating a new one.
[2023-08-07 08:59:10] [INFO]: Bot将在5秒后登录并开始信息处理, 按 Ctrl+C 取消.
[2023-08-07 08:59:10] [INFO]: 每 30 分钟将刷新一次签名 token
[2023-08-07 08:59:15] [INFO]: 开始尝试登录并同步消息...
[2023-08-07 08:59:15] [INFO]: 使用协议: Android Pad 8.9.63.11390
```