### PR TITLE
fix nil pointer dereference caused by nil 'cs'

### DIFF
--- a/cmd/gocq/qsign.go
+++ b/cmd/gocq/qsign.go
@@ -168,7 +168,7 @@ func energy(uin uint64, id string, _ string, salt []byte) ([]byte, error) {
 	}
 	data, err := hex.DecodeString(gjson.GetBytes(response, "data").String())
 	if err != nil {
-		log.Warnf("获取T544 sign时出现错误: %v", err)
+		log.Warnf("获取T544 sign时出现错误: %v (data: %v)", err, gjson.GetBytes(response, "data").String())
 		return nil, err
 	}
 	if len(data) == 0 {
@@ -397,7 +397,7 @@ func signStartRefreshToken(interval int64) {
 		cs, master := ss.get(), &base.SignServers[0]
 		if (cs == nil || cs.URL != master.URL) && isServerAvaliable(master.URL) {
 			ss.set(master)
-			log.Infof("主签名服务器可用，已切换至主签名服务器 %v", cs.URL)
+			log.Infof("主签名服务器可用，已切换至主签名服务器 %v", master.URL)
 		}
 		cs = ss.get()
 		if cs == nil {

--- a/cmd/gocq/qsign.go
+++ b/cmd/gocq/qsign.go
@@ -59,6 +59,9 @@ func getAvaliableSignServer() (*config.SignServer, error) {
 	if len(base.SignServers) == 0 {
 		return nil, errors.New("no sign server configured")
 	}
+	if len(base.SignServers) == 1 { // 只配置了一个签名服务时不检查以及切换
+		return &base.SignServers[0], nil
+	}
 	maxCount := base.Account.MaxCheckCount
 	if maxCount == 0 {
 		if errn.hasOver(3) {

--- a/cmd/gocq/qsign.go
+++ b/cmd/gocq/qsign.go
@@ -292,8 +292,9 @@ var lastToken = ""
 func sign(seq uint64, uin string, cmd string, qua string, buff []byte) (sign []byte, extra []byte, token []byte, err error) {
 	i := 0
 	for {
-		cs := ss.get()
+
 		sign, extra, token, err = signRequset(seq, uin, cmd, qua, buff)
+		cs := ss.get()
 		if cs == nil {
 			// 最好在请求后判断，否则若被设置为nil后不会再请求签名，
 			// 导致在下一次有请求签名服务操作之前，ss无法更新


### PR DESCRIPTION
* fix: #2437 
* optimize: 当仅配置一个签名服务时不进行检查可用以及切换操作(仅有一个时也没地方切换)
* energy 出现decode 错误时打印出导致错误的具体数据内容，便于发现问题（）
* fix: 修复在因某些原因（如qsign崩溃）导致当前签名服务被标记为不可用后，可能导致刷新token时提示uin未注册或者qsign未初始化的问题