### PR TITLE
尝试修复首次登录时容易出现 code -10005 和 packet timed out 的问题

### DIFF
--- a/cmd/gocq/qsign.go
+++ b/cmd/gocq/qsign.go
@@ -186,13 +186,15 @@ func energy(uin uint64, id string, _ string, salt []byte) ([]byte, error) {
 // 提交回调 buffer
 func signSubmit(uin string, cmd string, callbackID int64, buffer []byte, t string) {
 	buffStr := hex.EncodeToString(buffer)
-	tail := 64
-	endl := "..."
-	if len(buffStr) < tail {
-		tail = len(buffStr)
-		endl = "."
+	if base.Debug {
+		tail := 64
+		endl := "..."
+		if len(buffStr) < tail {
+			tail = len(buffStr)
+			endl = "."
+		}
+		log.Debugf("submit (%v): uin=%v, cmd=%v, callbackID=%v, buffer=%v%s", t, uin, cmd, callbackID, buffStr[:tail], endl)
 	}
-	log.Infof("submit (%v): uin=%v, cmd=%v, callbackID=%v, buffer=%v%s", t, uin, cmd, callbackID, buffStr[:tail], endl)
 
 	signServer, _, err := requestSignServer(
 		http.MethodGet,
@@ -208,6 +210,7 @@ func signSubmit(uin string, cmd string, callbackID int64, buffer []byte, t strin
 // signCallback
 // 刷新 token 和签名的回调
 func signCallback(uin string, results []gjson.Result, t string) {
+	time.Sleep(100 * time.Second)
 	for _, result := range results {
 		cmd := result.Get("cmd").String()
 		callbackID := result.Get("callbackId").Int()


### PR DESCRIPTION
* 此问题猜测可能是成功登录前无法向服务器发送 sso packet 并获取结果。 在有 callback 之前似乎没有出现这个问题，怀疑是这里的问题。 callback 改成等待 100s 后（以等待完成过滑块）再提交初始化包以尝试解决
* sign submit 内容改为仅在 debug 模式下打印