### PR TITLE
fix: switch ghproxy.com to mirror.ghproxy.com

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -483,7 +483,7 @@ func getRemoteLatestProtocolVersion(protocolType int) ([]byte, error) {
 	}
 	response, err := download.Request{URL: url}.Bytes()
 	if err != nil {
-		return download.Request{URL: "https://ghproxy.com/" + url}.Bytes()
+		return download.Request{URL: "https://mirror.ghproxy.com/" + url}.Bytes()
 	}
 	return response, nil
 }


### PR DESCRIPTION
ghproxy.com 已经被墙，根据其网页上的通知应当更换为二级域名 mirror.ghproxy.com，或考虑使用别的反代服务
![图片](https://github.com/Mrs4s/go-cqhttp/assets/43305366/573e2ef5-a3c6-42fc-8743-48e1f35b0d74)
