### PR TITLE
fix: switch ghproxy.com to mirror.ghproxy.com

### DIFF
--- a/cmd/gocq/main.go
+++ b/cmd/gocq/main.go
@@ -487,7 +487,7 @@ func getRemoteLatestProtocolVersion(protocolType int) ([]byte, error) {
 	}
 	response, err := download.Request{URL: url}.Bytes()
 	if err != nil {
-		return download.Request{URL: "https://ghproxy.com/" + url}.Bytes()
+		return download.Request{URL: "https://mirror.ghproxy.com/" + url}.Bytes()
 	}
 	return response, nil
 }


### PR DESCRIPTION
ghproxy.com 已经被墙，根据其网页上的通知应当更换为二级域名 mirror.ghproxy.com，或考虑使用别的反代服务