### PR TITLE
ci: attach provenance and SBOM attestations to the published image

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Hi, and thanks for go-cqhttp — and apologies for the noise on #2563.

I opened that one against `master` and your bot correctly closed it: *"Invalid PR to `non-dev` branch `master`."* This is the same change retargeted at `dev`, which is where it should have gone. My mistake, and the bot was right to catch it.

`.github/workflows/build_docker_image.yml` publishes the image, but the pushed manifest carries no provenance or SBOM attestation. Someone pulling it cannot check that it was built by this workflow, from this repository, at that commit.

go-cqhttp is run with account credentials and sits in the message path, so the image tends to be trusted with more than its size suggests.

The change is two lines on the build step:

```yaml
          push: ${{ github.event_name != 'pull_request' }}
          provenance: mode=max
          sbom: true
```

BuildKit attaches both to the image manifest, so they travel with the image. **No permissions change is needed** — nothing has to gain `id-token`, and your existing conditional push and cache configuration are untouched.

```
docker buildx imagetools inspect <image>:<tag> --format '{{ json .Provenance }}'
```

One note specific to this branch: the step here is `docker/build-push-action@v4`, which is the first version to support the `provenance:` and `sbom:` inputs — so this works as-is, but it is worth knowing that anything older would silently ignore them.

Two caveats: `mode=max` records the full build including build arguments, so `provenance: true` is the smaller option if any have ever been sensitive; and attestations add an extra manifest to the index, which the registry supports.

No SLSA level claimed — the attestation is what BuildKit produces.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
